### PR TITLE
State info sends as a per-channel parameter

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -706,8 +706,8 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     AP_GROUPINFO("ADSB",   9, GCS_MAVLINK, streamRates[9],  5),
 
     // @Param: STATEINFO
-    // @DisplayName: STATEINFO stream rate to ground station
-    // @Description: STATEINFO stream rate to ground station
+    // @DisplayName: STATEINFO stream enable to ground station
+    // @Description: STATEINFO stream enable to ground station
     // @Units: Enabale/disable
     // @Range: 0 1
     // @Increment: 1

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -11,7 +11,7 @@ void Copter::gcs_send_heartbeat(void)
 void Copter::gcs_send_stateinfo(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
+        if (gcs_chan[i].should_send_stateinfo() && gcs_chan[i].initialised) {
             gcs_chan[i].state_send();
         }
     }
@@ -704,6 +704,15 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("ADSB",   9, GCS_MAVLINK, streamRates[9],  5),
+
+    // @Param: STATEINFO
+    // @DisplayName: STATEINFO stream rate to ground station
+    // @Description: STATEINFO stream rate to ground station
+    // @Units: Enabale/disable
+    // @Range: 0 1
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("STATEINFO",   10, GCS_MAVLINK, streamStateInfo,  0),
 AP_GROUPEND
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -211,6 +211,8 @@ public:
     bool telemetry_delayed(mavlink_channel_t chan);
     virtual uint32_t telem_delay() const = 0;
 
+    bool should_send_stateinfo(void) { return streamStateInfo; };
+
 protected:
 
     // overridable method to check for packet acceptance. Allows for
@@ -231,6 +233,8 @@ protected:
 
     // saveable rate of each stream
     AP_Int16        streamRates[NUM_STREAMS];
+
+    AP_Int8 streamStateInfo; //If the stateinfo message should be streamed at 50hz
 
     void handle_request_data_stream(mavlink_message_t *msg, bool save);
     FUNCTOR_TYPEDEF(set_mode_fn, bool, uint8_t);


### PR DESCRIPTION
This PR adds a parameter to specify whether or not to stream the STATE_INFO message out of a given telemetry channel, e.g `SR1_STATEINFO`.  Making this a parameter allows us to enable it on one channel (telem1) but not another (telem2)