### PR TITLE
send current accel to planck_ctrl instead of delayed accel

### DIFF
--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -138,7 +138,7 @@ void AC_Planck::send_stateinfo(const mavlink_channel_t &chan,
   {
 
     Vector3f accel;
-    ahrs.get_NavEKF2().getAccelNED(accel);
+    ahrs.get_NavEKF2().getAccelNEDCurrent(accel);
 
     Vector3f gyro = ahrs.get_gyro_latest();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -827,6 +827,14 @@ void NavEKF2::getAccelNED(Vector3f &accelNED) const
     }
 }
 
+// This returns the specific forces in the NED frame at Current Time
+void NavEKF2::getAccelNEDCurrent(Vector3f &accelNEDCurrent) const
+{
+    if (core) {
+        core[primary].getAccelNEDCurrent(accelNEDCurrent);
+    }
+}
+
 // return body axis gyro bias estimates in rad/sec
 void NavEKF2::getGyroBias(int8_t instance, Vector3f &gyroBias) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -96,6 +96,9 @@ public:
     // This returns the specific forces in the NED frame
     void getAccelNED(Vector3f &accelNED) const;
 
+    // This returns the specific forces in the NED frame at Current Time
+    void getAccelNEDCurrent(Vector3f &accelNEDCurrent) const;
+
     // return body axis gyro bias estimates in rad/sec for the specified instance
     // An out of range instance (eg -1) returns data for the the primary instance
     void getGyroBias(int8_t instance, Vector3f &gyroBias) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -227,6 +227,12 @@ void NavEKF2_core::getAccelNED(Vector3f &accelNED) const {
     accelNED.z -= GRAVITY_MSS;
 }
 
+// This returns the specific forces in the NED frame at Current Time
+void NavEKF2_core::getAccelNEDCurrent(Vector3f &accelNEDCurrent) const {
+    accelNEDCurrent = velDotNEDCurrentFilt;
+    accelNEDCurrent.z -= GRAVITY_MSS;
+}
+
 // return the Z-accel bias estimate in m/s^2
 void NavEKF2_core::getAccelZBias(float &zbias) const {
     if (dtEkfAvg > 0) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -160,6 +160,7 @@ void NavEKF2_core::InitialiseVariables()
     dtEkfAvg = EKF_TARGET_DT;
     dt = 0;
     velDotNEDfilt.zero();
+    velDotNEDCurrentFilt.zero();
     lastKnownPositionNE.zero();
     prevTnb.zero();
     memset(&P[0][0], 0, sizeof(P));
@@ -668,6 +669,22 @@ void NavEKF2_core::calcOutputStates()
     // transform body delta velocities to delta velocities in the nav frame
     Vector3f delVelNav  = Tbn_temp*delVelNewCorrected;
     delVelNav.z += GRAVITY_MSS*imuDataNew.delVelDT;
+
+    // calculate the rate of change of velocity (used as corrected raw acel)
+    delNavDownSampled +=  delVelNav;
+    delVelDTDownSampled += imuDataNew.delVelDT;
+
+    if (delVelDTDownSampled > 0.010f){
+        //Compute average accel on last 12ms
+        velDotNEDCurrent = delNavDownSampled/delVelDTDownSampled;
+
+        // apply a first order lowpass filter: dt = 0.012s fc = 25Hz alpha = dt / (dt + 1/(2*pi*fc)), alpha = 0.6534
+        velDotNEDCurrentFilt = velDotNEDCurrent * 0.6534f + velDotNEDCurrentFilt * 0.3466f;
+
+        //Reset buffer
+        delNavDownSampled.zero();
+        delVelDTDownSampled = 0.0f;
+    }
 
     // save velocity for use in trapezoidal integration for position calcuation
     Vector3f lastVelocity = outputDataNew.velocity;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -101,6 +101,9 @@ public:
     // This returns the specific forces in the NED frame
     void getAccelNED(Vector3f &accelNED) const;
 
+    // This returns the specific forces in the NED frame at Current Time
+    void getAccelNEDCurrent(Vector3f &accelNEDCurrent) const;
+
     // return body axis gyro bias estimates in rad/sec
     void getGyroBias(Vector3f &gyroBias) const;
 
@@ -807,6 +810,10 @@ private:
     uint32_t lastMagUpdate_us;      // last time compass was updated in usec
     Vector3f velDotNED;             // rate of change of velocity in NED frame
     Vector3f velDotNEDfilt;         // low pass filtered velDotNED
+    Vector3f velDotNEDCurrent;      // rate of change of velocity in NED frame at Current Time
+    Vector3f velDotNEDCurrentFilt;  // low pass filtered velDotNEDCurrent
+    Vector3f delNavDownSampled;     // Accel data at the current time used to downsampled to a 100Hz rate
+    float delVelDTDownSampled;      // Delta time to downsampled the current time accel to a 100Hz rate
     uint32_t imuSampleTime_ms;      // time that the last IMU value was taken
     bool tasDataToFuse;             // true when new airspeed data is waiting to be fused
     uint32_t lastBaroReceived_ms;   // time last time we received baro height data


### PR DESCRIPTION
The accel data we get from APM is currently ~250 ms old, as it is being sourced from the oldest index in a time horizon buffer. The proposed change instead will source the accel data from the latest downsampled  IMU data. 

This change will significantly improve the pos/vel estimate drift that has been observed when the tag isn't being detected. Moreover, this will significantly reduce the large oscillations that sometimes occur when the tag is lost.