### PR TITLE
Planck copter 3.6.6 newarch jerkratio z

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -221,6 +221,7 @@ enum GuidedMode {
     Guided_Velocity,
     Guided_PosVel,
     Guided_Angle,
+    Guided_Angle_HighJerkZ,
 };
 
 // RTL states

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -220,7 +220,7 @@ enum GuidedMode {
     Guided_WP,
     Guided_Velocity,
     Guided_PosVel,
-    Guided_Angle
+    Guided_Angle,
 };
 
 // RTL states

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -220,8 +220,7 @@ enum GuidedMode {
     Guided_WP,
     Guided_Velocity,
     Guided_PosVel,
-    Guided_Angle,
-    Guided_Angle_HighJerkZ,
+    Guided_Angle
 };
 
 // RTL states

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -809,6 +809,7 @@ public:
     bool in_guided_mode() const { return true; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
 
+    void set_angle_highjerk_z(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool set_destination(const Location_Class& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -825,8 +826,9 @@ public:
 
     GuidedMode mode() const { return guided_mode; }
 
+    void angle_highjerk_z_control_start();
     void angle_control_start();
-    void angle_control_run();
+    void angle_control_run(bool high_jerk_z = false);
 
 protected:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -800,7 +800,8 @@ public:
     using Copter::Mode::Mode;
 
     bool init(bool ignore_checks) override;
-    void run() override;
+    void run() override { this->run(false); };
+    void run(bool high_jerk_z);
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
@@ -809,7 +810,6 @@ public:
     bool in_guided_mode() const { return true; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
 
-    void set_angle_highjerk_z(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool set_destination(const Location_Class& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -826,7 +826,6 @@ public:
 
     GuidedMode mode() const { return guided_mode; }
 
-    void angle_highjerk_z_control_start();
     void angle_control_start();
     void angle_control_run(bool high_jerk_z = false);
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -143,6 +143,35 @@ void Copter::ModeGuided::posvel_control_start()
     auto_yaw.set_mode(AUTO_YAW_HOLD);
 }
 
+// initialise guided mode's angle controller for high jerk ratio in Z (more agressive Z target)
+void Copter::ModeGuided::angle_highjerk_z_control_start()
+{
+    // set guided_mode to velocity controller
+    guided_mode = Guided_Angle_HighJerkZ;
+
+    // set vertical speed and acceleration
+    pos_control->set_speed_z(wp_nav->get_speed_down(), wp_nav->get_speed_up());
+    pos_control->set_accel_z(wp_nav->get_accel_z());
+
+    // initialise position and desired velocity
+    if (!pos_control->is_active_z()) {
+        pos_control->set_alt_target_to_current_alt();
+        pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
+    }
+
+    // initialise targets
+    guided_angle_state.update_time_ms = millis();
+    guided_angle_state.roll_cd = ahrs.roll_sensor;
+    guided_angle_state.pitch_cd = ahrs.pitch_sensor;
+    guided_angle_state.yaw_cd = ahrs.yaw_sensor;
+    guided_angle_state.climb_rate_cms = 0.0f;
+    guided_angle_state.yaw_rate_cds = 0.0f;
+    guided_angle_state.use_yaw_rate = false;
+
+    // pilot always controls yaw
+    auto_yaw.set_mode(AUTO_YAW_HOLD);
+}
+
 // initialise guided mode's angle controller
 void Copter::ModeGuided::angle_control_start()
 {
@@ -299,6 +328,36 @@ bool Copter::ModeGuided::set_destination_posvel(const Vector3f& destination, con
     return true;
 }
 
+// set guided mode angle target with higher jerk z for more agressive z target set point
+void Copter::ModeGuided::set_angle_highjerk_z(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads)
+{
+    // check we are in velocity control mode
+    if (guided_mode != Guided_Angle_HighJerkZ) {
+        angle_highjerk_z_control_start();
+    }
+
+    // convert quaternion to euler angles
+    q.to_euler(guided_angle_state.roll_cd, guided_angle_state.pitch_cd, guided_angle_state.yaw_cd);
+    guided_angle_state.roll_cd = ToDeg(guided_angle_state.roll_cd) * 100.0f;
+    guided_angle_state.pitch_cd = ToDeg(guided_angle_state.pitch_cd) * 100.0f;
+    guided_angle_state.yaw_cd = wrap_180_cd(ToDeg(guided_angle_state.yaw_cd) * 100.0f);
+    guided_angle_state.yaw_rate_cds = ToDeg(yaw_rate_rads) * 100.0f;
+    guided_angle_state.use_yaw_rate = use_yaw_rate;
+
+    guided_angle_state.climb_rate_cms = climb_rate_cms;
+    guided_angle_state.update_time_ms = millis();
+
+    // interpret positive climb rate as triggering take-off
+    if (motors->armed() && !ap.auto_armed && (guided_angle_state.climb_rate_cms > 0.0f)) {
+        copter.set_auto_armed(true);
+    }
+
+    // log target
+    copter.Log_Write_GuidedTarget(guided_mode,
+                           Vector3f(guided_angle_state.roll_cd, guided_angle_state.pitch_cd, guided_angle_state.yaw_cd),
+                           Vector3f(0.0f, 0.0f, guided_angle_state.climb_rate_cms));
+}
+
 // set guided mode angle target
 void Copter::ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads)
 {
@@ -360,7 +419,13 @@ void Copter::ModeGuided::run()
         // run angle controller
         angle_control_run();
         break;
+
+    case Guided_Angle_HighJerkZ:
+        // run angle controller
+        angle_control_run(true);
+        break;
     }
+
  }
 
 // guided_takeoff_run - takeoff in guided mode
@@ -575,7 +640,7 @@ void Copter::ModeGuided::posvel_control_run()
 
 // guided_angle_control_run - runs the guided angle controller
 // called from guided_run
-void Copter::ModeGuided::angle_control_run()
+void Copter::ModeGuided::angle_control_run(bool high_jerk_z)
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || !motors->get_interlock() || (ap.land_complete && guided_angle_state.climb_rate_cms <= 0.0f)) {
@@ -628,7 +693,7 @@ void Copter::ModeGuided::angle_control_run()
     }
 
     // call position controller
-    pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false);
+    pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false, high_jerk_z);
     pos_control->update_z_controller();
 }
 

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -10,6 +10,7 @@ bool Copter::ModePlanckLand::init(bool ignore_checks){
       return false;
     }
 
+    Copter::ModeGuided::set_angle(Quaternion(),0,true,0);
     if(Copter::ModeGuidedNoGPS::init(ignore_checks)) {
         float land_velocity = abs((copter.g.land_speed > 0 ?
             copter.g.land_speed : copter.pos_control->get_speed_down()))/100.;

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -178,7 +178,7 @@ void Copter::ModePlanckTracking::run() {
     }
 
     //Run the guided mode controller
-    Copter::ModeGuided::run();
+    Copter::ModeGuided::run(true); //use high-jerk
 }
 
 bool Copter::ModePlanckTracking::do_user_takeoff_start(float final_alt_above_home)

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -22,7 +22,7 @@ bool Copter::ModePlanckTracking::init(bool ignore_checks){
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
-      Copter::ModeGuided::set_angle(Quaternion(),0,true,0);
+      Copter::ModeGuided::set_angle_highjerk_z(Quaternion(),0,true,0);
       return copter.mode_guided_nogps.init(ignore_checks);
     }
 
@@ -76,7 +76,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(yaw_cd / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 
@@ -111,7 +111,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(att_cd.z / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -22,7 +22,7 @@ bool Copter::ModePlanckTracking::init(bool ignore_checks){
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
-      Copter::ModeGuided::set_angle_highjerk_z(Quaternion(),0,true,0);
+      Copter::ModeGuided::set_angle(Quaternion(),0,true,0);
       return copter.mode_guided_nogps.init(ignore_checks);
     }
 
@@ -76,7 +76,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(yaw_cd / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 
@@ -111,7 +111,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(att_cd.z / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -178,6 +178,15 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_ANGLE_MAX",  7, AC_PosControl, _lean_angle_max, 0.0f),
 
+    // @Param: _HIGH_JERK_RATIO
+    // @DisplayName: High jerk ratio
+    // @Description: Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T), higher to allow more agressive changes in z position target
+    // @Units: 1/s
+    // @Range: 1 10
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("_HIGH_JERK_RATIO",  8, AC_PosControl, _poscontrol_high_jerkratio, POSCONTROL_HIGH_JERK_RATIO),
+
     AP_GROUPEND
 };
 
@@ -210,6 +219,7 @@ AC_PosControl::AC_PosControl(const AP_AHRS_View& ahrs, const AP_InertialNav& ina
     _pitch_target(0.0f),
     _distance_to_target(0.0f),
     _accel_target_filter(POSCONTROL_ACCEL_FILTER_HZ)
+
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -335,10 +345,10 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     }
     accel_z_cms = constrain_float(accel_z_cms, 0.0f, 750.0f);
 
-    // jerk_z is calculated to reach full acceleration in 1000ms.
+    // jerk_z is calculated to reach full acceleration in (1/jerk_ratio) ms.
     float jerk_z = accel_z_cms * POSCONTROL_JERK_RATIO;
     if(high_jerk_z){
-        jerk_z = accel_z_cms * POSCONTROL_HIGH_JERK_RATIO;
+        jerk_z = accel_z_cms * _poscontrol_high_jerkratio;
     }
 
     float accel_z_max = MIN(accel_z_cms, safe_sqrt(2.0f*fabsf(_vel_desired.z - climb_rate_cms)*jerk_z));

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -323,7 +323,7 @@ void AC_PosControl::set_alt_target_from_climb_rate(float climb_rate_cms, float d
 ///     actual position target will be moved no faster than the speed_down and speed_up
 ///     target will also be stopped if the motors hit their limits or leash length is exceeded
 ///     set force_descend to true during landing to allow target to move low enough to slow the motors
-void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend)
+void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend, bool high_jerk_z)
 {
     // calculated increased maximum acceleration if over speed
     float accel_z_cms = _accel_z_cms;
@@ -337,6 +337,9 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
 
     // jerk_z is calculated to reach full acceleration in 1000ms.
     float jerk_z = accel_z_cms * POSCONTROL_JERK_RATIO;
+    if(high_jerk_z){
+        jerk_z = accel_z_cms * POSCONTROL_HIGH_JERK_RATIO;
+    }
 
     float accel_z_max = MIN(accel_z_cms, safe_sqrt(2.0f*fabsf(_vel_desired.z - climb_rate_cms)*jerk_z));
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -185,7 +185,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 1 10
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("_HIGH_JERK_RATIO",  8, AC_PosControl, _poscontrol_high_jerkratio, POSCONTROL_HIGH_JERK_RATIO),
+    AP_GROUPINFO("_HIGH_JERK",  8, AC_PosControl, _poscontrol_high_jerkratio, POSCONTROL_HIGH_JERK_RATIO),
 
     AP_GROUPEND
 };
@@ -348,6 +348,7 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     // jerk_z is calculated to reach full acceleration in (1/jerk_ratio) ms.
     float jerk_z = accel_z_cms * POSCONTROL_JERK_RATIO;
     if(high_jerk_z){
+        // hal.console->printf("Jerk ratio: %f \n", float(_poscontrol_high_jerkratio));
         jerk_z = accel_z_cms * _poscontrol_high_jerkratio;
     }
 
@@ -357,6 +358,14 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     _accel_last_z_cms = MIN(accel_z_max, _accel_last_z_cms);
 
     float vel_change_limit = _accel_last_z_cms * dt;
+
+    // if( climb_rate_cms < _vel_desired.z-vel_change_limit || climb_rate_cms > _vel_desired.z+vel_change_limit  ){
+    //   hal.console->printf("accel_z_max: %f accel_z_cms: %f jerk_z:%f\n", accel_z_max, accel_z_cms, jerk_z);
+
+    //   hal.console->printf("vel_change_limit: %f _accel_last_z_cms: %f \n", vel_change_limit,_accel_last_z_cms);
+    //   hal.console->printf("climb_rate_cms: %f lower_thres: %f upper_thres: %f\n", climb_rate_cms, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
+    // }
+
     _vel_desired.z = constrain_float(climb_rate_cms, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
     _flags.use_desvel_ff_z = true;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -219,7 +219,6 @@ AC_PosControl::AC_PosControl(const AP_AHRS_View& ahrs, const AP_InertialNav& ina
     _pitch_target(0.0f),
     _distance_to_target(0.0f),
     _accel_target_filter(POSCONTROL_ACCEL_FILTER_HZ)
-
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -348,7 +347,6 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     // jerk_z is calculated to reach full acceleration in (1/jerk_ratio) ms.
     float jerk_z = accel_z_cms * POSCONTROL_JERK_RATIO;
     if(high_jerk_z){
-        // hal.console->printf("Jerk ratio: %f \n", float(_poscontrol_high_jerkratio));
         jerk_z = accel_z_cms * _poscontrol_high_jerkratio;
     }
 
@@ -358,14 +356,6 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     _accel_last_z_cms = MIN(accel_z_max, _accel_last_z_cms);
 
     float vel_change_limit = _accel_last_z_cms * dt;
-
-    // if( climb_rate_cms < _vel_desired.z-vel_change_limit || climb_rate_cms > _vel_desired.z+vel_change_limit  ){
-    //   hal.console->printf("accel_z_max: %f accel_z_cms: %f jerk_z:%f\n", accel_z_max, accel_z_cms, jerk_z);
-
-    //   hal.console->printf("vel_change_limit: %f _accel_last_z_cms: %f \n", vel_change_limit,_accel_last_z_cms);
-    //   hal.console->printf("climb_rate_cms: %f lower_thres: %f upper_thres: %f\n", climb_rate_cms, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
-    // }
-
     _vel_desired.z = constrain_float(climb_rate_cms, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
     _flags.use_desvel_ff_z = true;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -36,8 +36,8 @@
 #define POSCONTROL_VEL_ERROR_CUTOFF_FREQ        4.0f    // low-pass filter on velocity error (unit: hz)
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ         2.0f    // low-pass filter on accel error (unit: hz)
 #define POSCONTROL_ACCEL_FILTER_HZ              2.0f    // low-pass filter on acceleration (unit: hz)
-#define POSCONTROL_JERK_RATIO                   1.0f    // Defines the time it takes to reach the requested acceleration
-#define POSCONTROL_HIGH_JERK_RATIO              10.0f   // Defines the time it takes to reach the requested acceleration, higher to allow more agressive changes in z position target
+#define POSCONTROL_JERK_RATIO                   1.0f    // Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T)
+#define POSCONTROL_HIGH_JERK_RATIO              10.0f   // Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T), higher to allow more agressive changes in z position target
 
 #define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
 
@@ -379,6 +379,7 @@ protected:
     AC_PID      _pid_accel_z;
     AC_P        _p_pos_xy;
     AC_PID_2D   _pid_vel_xy;
+    AP_Float    _poscontrol_high_jerkratio; // Defines the time it takes to reach the requested acceleration in z: higher to allow more agressive changes in z position target
 
     // internal variables
     float       _dt;                    // time difference (in seconds) between calls from the main program

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -37,6 +37,7 @@
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ         2.0f    // low-pass filter on accel error (unit: hz)
 #define POSCONTROL_ACCEL_FILTER_HZ              2.0f    // low-pass filter on acceleration (unit: hz)
 #define POSCONTROL_JERK_RATIO                   1.0f    // Defines the time it takes to reach the requested acceleration
+#define POSCONTROL_HIGH_JERK_RATIO              10.0f   // Defines the time it takes to reach the requested acceleration, higher to allow more agressive changes in z position target
 
 #define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
 
@@ -107,7 +108,7 @@ public:
     ///     actual position target will be moved no faster than the speed_down and speed_up
     ///     target will also be stopped if the motors hit their limits or leash length is exceeded
     ///     set force_descend to true during landing to allow target to move low enough to slow the motors
-    virtual void set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend);
+    virtual void set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend, bool high_jerk_z = false);
 
     /// add_takeoff_climb_rate - adjusts alt target up or down using a climb rate in cm/s
     ///     should be called continuously (with dt set to be the expected time between calls)

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -37,7 +37,7 @@
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ         2.0f    // low-pass filter on accel error (unit: hz)
 #define POSCONTROL_ACCEL_FILTER_HZ              2.0f    // low-pass filter on acceleration (unit: hz)
 #define POSCONTROL_JERK_RATIO                   1.0f    // Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T)
-#define POSCONTROL_HIGH_JERK_RATIO              10.0f   // Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T), higher to allow more agressive changes in z position target
+#define POSCONTROL_HIGH_JERK_RATIO              1.0f   // Defines the time (delta_T) it takes to reach the requested acceleration as ratio = (1/delta_T), higher to allow more agressive changes in z position target
 
 #define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
 

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -42,7 +42,7 @@ void AC_PosControl_Sub::set_alt_target_from_climb_rate(float climb_rate_cms, flo
 ///     actual position target will be moved no faster than the speed_down and speed_up
 ///     target will also be stopped if the motors hit their limits or leash length is exceeded
 ///     set force_descend to true during landing to allow target to move low enough to slow the motors
-void AC_PosControl_Sub::set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend)
+void AC_PosControl_Sub::set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend, bool high_jerk_z)
 {
     // calculated increased maximum acceleration if over speed
     float accel_z_cms = _accel_z_cms;

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
@@ -29,7 +29,7 @@ public:
     ///     actual position target will be moved no faster than the speed_down and speed_up
     ///     target will also be stopped if the motors hit their limits or leash length is exceeded
     ///     set force_descend to true during landing to allow target to move low enough to slow the motors
-    void set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend) override;
+    void set_alt_target_from_climb_rate_ff(float climb_rate_cms, float dt, bool force_descend, bool high_jerk_z = false) override;
 
 private:
     float       _alt_max; // max altitude - should be updated from the main code with altitude limit from fence


### PR DESCRIPTION
Allow to increase Jerk Limit and Acceleration when setting `alt_cmd` from `z_rate_cmd`:

- `PSC_HIGH_JERK`: Parameter to increase the jerk ratio limit (higher = more aggressive): Default `1.0f` / More agressive `10.0f`
- `WPNAV_ACCEL_Z`:  Parameter to increase the acceleration limit:  Default `100.0` / More agressive `250.0`