### PR TITLE
Planck copter 3.6.6 newarch jerkratio z reduction

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -220,7 +220,7 @@ enum GuidedMode {
     Guided_WP,
     Guided_Velocity,
     Guided_PosVel,
-    Guided_Angle
+    Guided_Angle,
 };
 
 // RTL states

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -220,8 +220,7 @@ enum GuidedMode {
     Guided_WP,
     Guided_Velocity,
     Guided_PosVel,
-    Guided_Angle,
-    Guided_Angle_HighJerkZ,
+    Guided_Angle
 };
 
 // RTL states

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -800,7 +800,8 @@ public:
     using Copter::Mode::Mode;
 
     bool init(bool ignore_checks) override;
-    void run() override;
+    void run() override { this->run(false); };
+    void run(bool high_jerk_z);
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
@@ -809,7 +810,6 @@ public:
     bool in_guided_mode() const { return true; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
 
-    void set_angle_highjerk_z(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool set_destination(const Location_Class& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -826,7 +826,6 @@ public:
 
     GuidedMode mode() const { return guided_mode; }
 
-    void angle_highjerk_z_control_start();
     void angle_control_start();
     void angle_control_run(bool high_jerk_z = false);
 

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -178,7 +178,7 @@ void Copter::ModePlanckTracking::run() {
     }
 
     //Run the guided mode controller
-    Copter::ModeGuided::run();
+    Copter::ModeGuided::run(true); //use high-jerk
 }
 
 bool Copter::ModePlanckTracking::do_user_takeoff_start(float final_alt_above_home)

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -22,7 +22,7 @@ bool Copter::ModePlanckTracking::init(bool ignore_checks){
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
-      Copter::ModeGuided::set_angle_highjerk_z(Quaternion(),0,true,0);
+      Copter::ModeGuided::set_angle(Quaternion(),0,true,0);
       return copter.mode_guided_nogps.init(ignore_checks);
     }
 
@@ -76,7 +76,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(yaw_cd / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 
@@ -111,7 +111,7 @@ void Copter::ModePlanckTracking::run() {
               float yaw_rate_rads = ToRad(att_cd.z / 100.);
 
               //Update the GUIDED mode controller
-              Copter::ModeGuided::set_angle_highjerk_z(q,vz_cms,is_yaw_rate,yaw_rate_rads);
+              Copter::ModeGuided::set_angle(q,vz_cms,is_yaw_rate,yaw_rate_rads);
               break;
           }
 


### PR DESCRIPTION
This PR reduces the amount of code in `[planck_Copter-3.6.6_newarch_jerkratio_z](https://github.com/planckaero/ardupilot/pull/6)` by overloading the `run()` method of `ModeGuided`