### PR TITLE
Don't scale planck state vel

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2190,11 +2190,7 @@ void GCS_MAVLINK::send_planck_stateinfo() const
     Vector3f gyro = ahrs.get_gyro_latest();
 
     Vector3f vel;
-    if(ahrs.get_velocity_NED(vel))
-    {
-        vel /= 100;
-    }
-    else
+    if(!ahrs.get_velocity_NED(vel))
     {
         vel.zero();
     }


### PR DESCRIPTION
in 3_6_6, the vel sent was first obtained as cm/s, and needed to be converted to m/s.
in 4_0_x, the vel sent is obtained as m/s, so needs no conversion

This causes issues in planck_ctrl, as planck_ctrl was receiving the DR_STATE vel in cm/s, but expects m/s