### PR TITLE
Use correct ekf version check !TESTING STILL REQUIRED!

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -319,6 +319,11 @@ public:
         return false;
     }
 
+    // return the current acc estimate in meters/second^2, North/East/Down
+    // order. Must only be called if have_inertial_nav() is true
+    virtual bool get_accel_NED_Current(Vector3f &vec) const WARN_IF_UNUSED {
+        return false;
+    }
     // returns the expected NED magnetic field
     virtual bool get_expected_mag_field_NED(Vector3f &ret) const WARN_IF_UNUSED {
         return false;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -324,6 +324,7 @@ public:
     virtual bool get_accel_NED_Current(Vector3f &vec) const WARN_IF_UNUSED {
         return false;
     }
+
     // returns the expected NED magnetic field
     virtual bool get_expected_mag_field_NED(Vector3f &ret) const WARN_IF_UNUSED {
         return false;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -673,6 +673,25 @@ bool AP_AHRS_NavEKF::get_velocity_NED(Vector3f &vec) const
     }
 }
 
+// return the current acc estimate in meters/second^2, North/East/Down
+// order. Must only be called if have_inertial_nav() is true
+bool AP_AHRS_NavEKF::get_accel_NED_Current(Vector3f &vec) const
+{
+    switch (active_EKF_type()) {
+    case EKF_TYPE_NONE:
+        return false;
+
+    case EKF_TYPE2:
+    default:
+        EKF2.getAccelNEDCurrent(vec);
+        return true;
+
+    case EKF_TYPE3:
+        EKF3.getAccelNEDCurrent(vec);
+        return true;
+    }
+}
+
 // returns the expected NED magnetic field
 bool AP_AHRS_NavEKF::get_mag_field_NED(Vector3f &vec) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -136,6 +136,8 @@ public:
 
     bool get_velocity_NED(Vector3f &vec) const override;
 
+    bool get_accel_NED_Current(Vector3f &vec) const override;
+
     // return the relative position NED to either home or origin
     // return true if the estimate is valid
     bool get_relative_position_NED_home(Vector3f &vec) const override;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2171,18 +2171,8 @@ void GCS_MAVLINK::send_planck_stateinfo() const
     const AP_AHRS &ahrs = AP::ahrs();
 
     Vector3f accel;
-    const NavEKF2 &ekf2 = AP::ahrs_navekf().get_NavEKF2_const();
-    const NavEKF3 &ekf3 = AP::ahrs_navekf().get_NavEKF3_const();
 
-    if(ekf3.activeCores() > 0)
-    {
-      ekf3.getAccelNEDCurrent(accel);
-    }
-    else if(ekf2.activeCores() > 0)
-    {
-      ekf2.getAccelNEDCurrent(accel);
-    }
-    else
+    if(!ahrs.get_accel_NED_Current(accel))
     {
         accel.zero();
     }


### PR DESCRIPTION
This PR corrects an existing bug that incorrectly checks the number of active ekf cores to determine which version to use (ekf2/ekf3). APM allows cores of both ekf2 and ekf3 to run simultaneously, though only one is used for control (changing which one is used requires a restart).

The current logic to use which ekf to use for planck state message acc only checks the number of active cores, and will always use ekf3 if it has an active core. However, it is possible to have ekf3 and ekf3 cores active, while using ekf2 for control. Thus, it would be sending ekf3 data to planck, though using ekf2 data for control, which is undesirable. The data sent to planck should match the data being used for control.

This PR proposes a resolution by adding a get_accel_NED_Current() method to the AHRS, which will automatically select the ekf core being used for control, and return the current ned accel estimate for that core. This is an analog to the extant get_velocity_NED() method in AHRS

!!TEST PRIOR TO MERGE!!