### PR TITLE
Use baro based rel alt when origin not set

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2194,7 +2194,7 @@ void GCS_MAVLINK::send_planck_stateinfo() const
     if(current_loc.initialised()) {
         if(!current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm))
         {
-            alt_above_home_cm = 0;
+            alt_above_home_cm = global_position_int_relative_alt()/10;
         }
         if(!current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_above_sea_level_cm))
         {


### PR DESCRIPTION
This proposed code change will, when the EKF origin has not been set (eg bad gps), force the alt above home value sent in the DR_STATE message to be sourced from the EKF baro alt. It leverages existing APM code to get the desired value when the origin/home hasn't been set. If the origin/home has been set, it uses the current pathway , ie get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm).

Currently, if the origin/home has not been set, the alt above home in the DR_STATE message is always 0, which causes the cmd alt in planck ctrl to be 1m

data from the test can be found here:
https://www.dropbox.com/home/TestingNew/2020/2020_04_01_Indoor_Iris_EKF2_3
