### PR TITLE
When in RTB, using GPS POSVEL cmds, cmd yaw based on vel_cmd

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -174,7 +174,20 @@ void ModePlanckTracking::run() {
                           pos_cmd.z = new_alt_cm;
                       }
                   }
-                  ModeGuided::set_destination_posvel(pos_cmd,vel_cmd);
+
+                  float desired_yaw_cd;
+                  //If within 2.5 m of the target, use current heading, else cmd heading based on vel cmd
+                  //Using default Planck KP_GPS of 0.4 -> (1.0 m/s) / (0.4) = 2.5 m
+                  if(vel_cmd.length() > 1.0)
+                  {
+                    desired_yaw_cd = degrees(atan2f(vel_cmd.y,vel_cmd.x))*100.0f;
+                  }
+                  else
+                  {
+                    desired_yaw_cd = copter.attitude_control->get_att_target_euler_cd().z;
+                  }
+
+                  ModeGuided::set_destination_posvel(pos_cmd,vel_cmd,true,desired_yaw_cd);
               }
               break;
           }


### PR DESCRIPTION
This PR will set a fixed yaw command in the direction of the velocity command when: in planck sends a POS_VEL command type, ie RTB, using GPS tracking, and greater than ~2.5 meters from the tag

addresses https://planckaero.atlassian.net/browse/ACE-438

!!!still needs to be tested, at the moment only a review is being requested!!!!