### PR TITLE
Use baro based rel alt when origin not set

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2196,7 +2196,7 @@ void GCS_MAVLINK::send_planck_stateinfo() const
     if(current_loc.initialised()) {
         if(!current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm))
         {
-            alt_above_home_cm = 0;
+            alt_above_home_cm = global_position_int_relative_alt()/10;
         }
         if(!current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_above_sea_level_cm))
         {


### PR DESCRIPTION
same as https://github.com/planckaero/ardupilot/pull/12
the above PR for 4.0.1 somehow didnt get put in 4.0.3