### PR TITLE
Fix irregular STATEINFO data transmission

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -92,6 +92,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(rc_loop,              100,    130),
     SCHED_TASK(throttle_loop,         50,     75),
     SCHED_TASK(update_GPS,            50,    200),
+    SCHED_TASK_CLASS(GCS,                  (GCS*)&copter._gcs,          send_planck_stateinfo,    100, 100),
 #if OPTFLOW == ENABLED
     SCHED_TASK_CLASS(OpticalFlow,          &copter.optflow,             update,         200, 160),
 #endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -216,12 +216,12 @@ public:
     void send_sys_status();
     void send_set_position_target_global_int(uint8_t target_system, uint8_t target_component, const Location& loc);
     void send_rpm() const;
-    void send_planck_stateinfo() const;
+    void send_planck_stateinfo();
 
     bool locked() const;
 
     // return a bitmap of active channels. Used by libraries to loop
-    // over active channels to send to all active channels    
+    // over active channels to send to all active channels
     static uint8_t active_channel_mask(void) { return mavlink_active; }
 
     // return a bitmap of streaming channels
@@ -235,7 +235,7 @@ public:
     static bool is_private(mavlink_channel_t _chan) {
         return (mavlink_private & (1U<<(unsigned)_chan)) != 0;
     }
-    
+
     // return true if channel is private
     bool is_private(void) const { return is_private(chan); }
 
@@ -249,7 +249,7 @@ public:
       allow forwarding of packets / heartbeats to be blocked as required by some components to reduce traffic
     */
     static void disable_channel_routing(mavlink_channel_t chan) { routing.no_route_mask |= (1U<<(chan-MAVLINK_COMM_0)); }
-    
+
     /*
       search for a component in the routing table with given mav_type and retrieve it's sysid, compid and channel
       returns if a matching component is found
@@ -531,6 +531,9 @@ private:
     uint8_t sending_bucket_id = no_bucket_to_send;
     Bitmask<MSG_LAST> bucket_message_ids_to_send;
 
+    //Last time we sent a planck_stateinfo
+    uint16_t last_planck_stateinfo_sent_ms = 0;
+
     ap_message next_deferred_bucket_message_to_send();
     void find_next_bucket_to_send();
     void remove_message_from_bucket(int8_t bucket, ap_message id);
@@ -578,7 +581,7 @@ private:
 
     // time when we missed sending a parameter for GCS
     static uint32_t reserve_param_space_start_ms;
-    
+
     // bitmask of what mavlink channels are active
     static uint8_t mavlink_active;
 
@@ -598,7 +601,7 @@ private:
     };
 
     struct pending_param_reply {
-        mavlink_channel_t chan;        
+        mavlink_channel_t chan;
         float value;
         enum ap_var_type p_type;
         int16_t param_index;
@@ -657,7 +660,7 @@ private:
 
     struct pending_ftp {
         uint32_t offset;
-        mavlink_channel_t chan;        
+        mavlink_channel_t chan;
         uint16_t seq_number;
         FTP_OP opcode;
         FTP_OP req_opcode;
@@ -730,11 +733,11 @@ private:
       since boot in milliseconds
      */
     uint32_t correct_offboard_timestamp_usec_to_ms(uint64_t offboard_usec, uint16_t payload_size);
-    
+
     mavlink_signing_t signing;
     static mavlink_signing_streams_t signing_streams;
     static uint32_t last_signing_save_ms;
-    
+
     static StorageAccess _signing_storage;
     static bool signing_key_save(const struct SigningKey &key);
     static bool signing_key_load(struct SigningKey &key);
@@ -751,7 +754,7 @@ private:
     } alternative;
 
     JitterCorrection lag_correction;
-    
+
     // we cache the current location and send it even if the AHRS has
     // no idea where we are:
     struct Location global_position_current_loc;
@@ -819,6 +822,7 @@ public:
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_named_float(const char *name, float value) const;
+    void send_planck_stateinfo();
 
     void send_parameter_value(const char *param_name,
                               ap_var_type param_type,

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -145,6 +145,10 @@ void GCS_MAVLINK::handle_request_data_stream(const mavlink_message_t &msg)
                 // considered "internal".
                 continue;
             }
+            if (i == STREAM_PLANCK) {
+                // don't touch planck_stateinfo
+                continue;
+            }
             if (persist_streamrates()) {
                 streamRates[i].set_and_save_ifchanged(freq);
             } else {
@@ -224,7 +228,7 @@ void GCS_MAVLINK::handle_param_request_read(const mavlink_message_t &msg)
         // we can't process this right now, drop it
         return;
     }
-    
+
     mavlink_param_request_read_t packet;
     mavlink_msg_param_request_read_decode(&msg, &packet);
 
@@ -361,7 +365,7 @@ void GCS_MAVLINK::param_io_timer(void)
         // no room
         return;
     }
-    
+
     if (!param_requests.pop(req)) {
         // nothing to do
         return;


### PR DESCRIPTION
This PR addresses [ACE-513](https://planckaero.atlassian.net/browse/ACE-513?atlOrigin=eyJpIjoiMWE1MjJhMjgxNGYzNDAwYWEzOGQyNWQ0NTI5MTNlOGIiLCJwIjoiaiJ9)

`PLANCK_STATEINFO` messages were being generated and transmitted irregularly.  This appears to have been due to APM's internal (and new to 4.0) data stream code, which rate-limits messages based on CPU loading and the amount of data being transmitted.

This PR reinstates 3.6.6-like functionality by adding a 100hz high-priority scheduled task which sends `PLANCK_STATEINFO` messages at the requested streamrate, bypassing the APM stream code.

![image](https://user-images.githubusercontent.com/5853291/81339872-b6b99880-9063-11ea-9efa-9c3670290121.png)
