### PR TITLE
Mission cmd fix

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2000,6 +2000,12 @@ const char *AP_Mission::Mission_Command::type() const {
         return "PayloadPlace";
     case MAV_CMD_DO_PARACHUTE:
         return "Parachute";
+    case MAV_CMD_NAV_PLANCK_TAKEOFF:
+        return "PlanckTakeoff";
+    case MAV_CMD_NAV_PLANCK_RTB:
+        return "PlanckRTB";
+    case MAV_CMD_NAV_PLANCK_WINGMAN:
+        return "PlanckWingman";
 
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2196,7 +2196,7 @@ void GCS_MAVLINK::send_planck_stateinfo() const
     if(current_loc.initialised()) {
         if(!current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm))
         {
-            alt_above_home_cm = 0;
+            alt_above_home_cm = global_position_int_relative_alt()/10;
         }
         if(!current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_above_sea_level_cm))
         {


### PR DESCRIPTION
in AP_Mission::Mission_Command::type(), it checks the command type to determine which text to send to the GCS for a mission command. However, it uses a switch statement, and no planck command type are included. In regular flight, this will result in a "?" being sent, while in sim this will crash the SITL due to the lines:
'#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
        AP_HAL::panic("Mission command with ID %u has no string", id);
#endif'

Thus, running missions with planck commands in sim will crash the sim
this PR adds planck modes to the switch statement