### PR TITLE
Fix check on when to allow an alt change reqest

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1100,7 +1100,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
                 //if we are not currently flying
                 if((copter.planck_interface.get_tag_tracking_state() ||
                     copter.planck_interface.get_commbox_state()) &&
-                   copter.ap.land_complete)
+                    !copter.ap.land_complete)
                 {
                     copter.planck_interface.request_alt_change(pos_vector.z / 100.);
                 }


### PR DESCRIPTION
Changing altitude via QGC while in RTB/Planck Track is broken. The user can enter the command, with no error indication,  but nothing happens. Analysis has shown that a check on when to allow this command is broken. It should allow the command if both of the following are true

1. there is a good tag estimate OR an good commbox position estimate
2. the aircraft has NOT completed landing

However, currently the logic _**prevents**_ the command from being sent to planck control if item 2 is true.

This PR fixes the logic so it  **_allows_** the command when both 1 and 2 are true

it has been verified to fix the issue in sim

resolves https://planckaero.atlassian.net/browse/ACE-561