### PR TITLE
Pack ACE version in (unused) middleware string

### DIFF
--- a/ArduCopter/version.cpp
+++ b/ArduCopter/version.cpp
@@ -32,7 +32,7 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_hash_str = GIT_VERSION,
 #endif
     .middleware_name = nullptr,
-    .middleware_hash_str = nullptr,
+    .middleware_hash_str = ACEVERSION,
 #ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,6 +6,7 @@
 
 #include "ap_version.h"
 
+#define ACEVERSION "v1.0.3"
 #define THISFIRMWARE "ArduCopter V4.0.3 ACE Copter v1.0.3"
 
 // the following line is parsed by the autotest scripts


### PR DESCRIPTION
Part of [ACE-564](https://planckaero.atlassian.net/browse/ACE-564?atlOrigin=eyJpIjoiZTQwNjI5OWY4YTU4NDE1MDg0MzI3NzJmMmMzMTc5YTMiLCJwIjoiaiJ9)

Report the ACE-specific version in the `middleware_hash_str` of `AP_FWVersion` and `middleware_custom_version` field of the `AUTOPILOT_VERSION` mavlink message.  The `middleware_custom_version` is currently unused.  This may be used in the future for APM, but it appears to be the most convenient field to pack a custom firmware version, beyond the git hash which is already packed inside the `flight_custom_version` field.