### PR TITLE
GCS_Common: 64bit planck timer

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -532,7 +532,7 @@ private:
     Bitmask<MSG_LAST> bucket_message_ids_to_send;
 
     //Last time we sent a planck_stateinfo
-    uint16_t last_planck_stateinfo_sent_ms = 0;
+    uint64_t last_planck_stateinfo_sent_ms = 0;
 
     ap_message next_deferred_bucket_message_to_send();
     void find_next_bucket_to_send();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2168,15 +2168,15 @@ void GCS::send_planck_stateinfo()
 void GCS_MAVLINK::send_planck_stateinfo()
 {
     //Sanity check
-    uint16_t now = AP_HAL::millis16();
+    uint64_t now = AP_HAL::millis64();
     if(now <= last_planck_stateinfo_sent_ms) {
         last_planck_stateinfo_sent_ms = now;
         return;
     }
 
     //Don't send if its too soon
-    uint16_t interval = get_interval_for_stream(STREAM_PLANCK);
-    uint16_t dt = now - last_planck_stateinfo_sent_ms;
+    uint64_t interval = get_interval_for_stream(STREAM_PLANCK);
+    uint64_t dt = now - last_planck_stateinfo_sent_ms;
     if((interval == 0) || (dt < (interval - interval/10))) { //within 10%
         return;
     }


### PR DESCRIPTION
[ACE-602](https://planckaero.atlassian.net/browse/ACE-602?atlOrigin=eyJpIjoiNWMwYTFjZmIyNWI2NGM0OWEyNmM0ZDE4MmQzZjhhNTgiLCJwIjoiaiJ9)

This fixes occasional dropped STATEINFO packets.  Since the `last_planck_stateinfo_sent_ms` was only 16 bits, it would wrap every ~65s, resulting in a dropped packet.  This uses a 64bit variable instead, eliminating the wrap problem.

![Screen Shot 2020-08-26 at 1 55 02 PM](https://user-images.githubusercontent.com/5853291/91356434-89286480-e7a4-11ea-8936-77afad2a109a.png)
