### PR TITLE
Planck copter 4.0.3 tilt failsafe

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -749,7 +749,7 @@ private:
     void failsafe_terrain_set_status(bool data_ok);
     void failsafe_terrain_on_event();
     void gpsglitch_check();
-    void failsafe_lean_check(uint16_t duration_ms);
+    void failsafe_lean_check();
     void failsafe_lean_on_event();
     void set_mode_RTL_or_land_with_pause(ModeReason reason);
     void set_mode_SmartRTL_or_RTL(ModeReason reason);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -415,6 +415,7 @@ private:
         uint32_t last_heartbeat_ms;      // the time when the last HEARTBEAT message arrived from a GCS - used for triggering gcs failsafe
         uint32_t terrain_first_failure_ms;  // the first time terrain data access failed - used to calculate the duration of the failure
         uint32_t terrain_last_failure_ms;   // the most recent time terrain data access failed
+        uint32_t lean_high_time_ms;   // time of rising edge for high lean
 
         int8_t radio_counter;            // number of iterations with throttle below throttle_fs_value
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -423,6 +423,8 @@ private:
         uint8_t ekf                 : 1; // true if ekf failsafe has occurred
         uint8_t terrain             : 1; // true if the missing terrain data failsafe has occurred
         uint8_t adsb                : 1; // true if an adsb related failsafe has occurred
+        uint8_t lean                : 1; // true if a lean-angle failsafe has occurred
+        uint8_t thr2wt              : 1; // true if a thrust-to-weight failsafe has occurred
     } failsafe;
 
     bool any_failsafe_triggered() const {
@@ -747,6 +749,8 @@ private:
     void failsafe_terrain_set_status(bool data_ok);
     void failsafe_terrain_on_event();
     void gpsglitch_check();
+    void failsafe_lean_check(uint32_t duration_ms);
+    void failsafe_lean_on_event();
     void set_mode_RTL_or_land_with_pause(ModeReason reason);
     void set_mode_SmartRTL_or_RTL(ModeReason reason);
     void set_mode_SmartRTL_or_land_with_pause(ModeReason reason);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -749,7 +749,7 @@ private:
     void failsafe_terrain_set_status(bool data_ok);
     void failsafe_terrain_on_event();
     void gpsglitch_check();
-    void failsafe_lean_check(uint32_t duration_ms);
+    void failsafe_lean_check(uint16_t duration_ms);
     void failsafe_lean_on_event();
     void set_mode_RTL_or_land_with_pause(ModeReason reason);
     void set_mode_SmartRTL_or_RTL(ModeReason reason);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -425,7 +425,6 @@ private:
         uint8_t terrain             : 1; // true if the missing terrain data failsafe has occurred
         uint8_t adsb                : 1; // true if an adsb related failsafe has occurred
         uint8_t lean                : 1; // true if a lean-angle failsafe has occurred
-        uint8_t thr2wt              : 1; // true if a thrust-to-weight failsafe has occurred
     } failsafe;
 
     bool any_failsafe_triggered() const {

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1105,7 +1105,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_arming_check_old,   0,      AP_PARAM_INT8,  "ARMING_CHECK" },
     // battery
     { Parameters::k_param_fs_batt_voltage,    0,      AP_PARAM_FLOAT,  "BATT_LOW_VOLT" },
-  //  { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT,  "BATT_LOW_MAH" },
     { Parameters::k_param_failsafe_battery_enabled,0, AP_PARAM_INT8,   "BATT_FS_LOW_ACT" },
 
     { Parameters::Parameters::k_param_ch7_option_old,   0,      AP_PARAM_INT8,  "RC7_OPTION" },

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -376,6 +376,14 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     ASCALAR(planck_angle_max, "PLANCK_ANGLE_MAX",                 DEFAULT_PLANCK_ANGLE_MAX),
 
+    // @Param: PLANCK_ANGLE_TO
+    // @DisplayName: Planck Angle Timeout
+    // @Description: Time above PLANCK_ANGLE_MAX before triggering failsafe
+    // @Units: milliseconds
+    // @Range: 0 60000
+    // @User: Advanced
+    GSCALAR(planck_angle_fs_to, "PLANCK_ANG_FS_TO",                 FS_LEAN_TIMEOUT_MS),
+
     // @Param: PHLD_BRAKE_RATE
     // @DisplayName: PosHold braking rate
     // @Description: PosHold flight mode's rotation rate during braking in deg/sec

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -368,6 +368,14 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     ASCALAR(angle_max, "ANGLE_MAX",                 DEFAULT_ANGLE_MAX),
 
+    // @Param: PLANCK_ANGLE_MAX
+    // @DisplayName: Planck Angle Max
+    // @Description: Maximum lean angle in planck flight modes
+    // @Units: cdeg
+    // @Range: 1000 8000
+    // @User: Advanced
+    ASCALAR(planck_angle_max, "PLANCK_ANGLE_MAX",                 DEFAULT_PLANCK_ANGLE_MAX),
+
     // @Param: PHLD_BRAKE_RATE
     // @DisplayName: PosHold braking rate
     // @Description: PosHold flight mode's rotation rate during braking in deg/sec
@@ -1082,7 +1090,7 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_arming_check_old,   0,      AP_PARAM_INT8,  "ARMING_CHECK" },
     // battery
     { Parameters::k_param_fs_batt_voltage,    0,      AP_PARAM_FLOAT,  "BATT_LOW_VOLT" },
-    { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT,  "BATT_LOW_MAH" },
+  //  { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT,  "BATT_LOW_MAH" },
     { Parameters::k_param_failsafe_battery_enabled,0, AP_PARAM_INT8,   "BATT_FS_LOW_ACT" },
 
     { Parameters::Parameters::k_param_ch7_option_old,   0,      AP_PARAM_INT8,  "RC7_OPTION" },

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -384,6 +384,13 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_angle_fs_to, "PLANCK_ANG_FS_TO",                 FS_LEAN_TIMEOUT_MS),
 
+    // @Param: FS_ANGLE_ENABLE
+    // @DisplayName: Planck Angle Failsafe Enable
+    // @Description: Controls whether failsafe will be invoked (and what action to take) when lean angle is higher than PLANCK_ANGLE_MAX for long enough. This failsafe is only active when in Planck Track, Planck RTB, or Planck Land.
+    // @Values: 0:Disabled,1: Enabled always Planck Track or Planck land, 2:Enabled Only Warn
+    // @User: Standard
+    GSCALAR(failsafe_planck_angle, "FS_ANGLE_ENABLE", FS_PLANCK_ANGLE_DISABLED),
+
     // @Param: PHLD_BRAKE_RATE
     // @DisplayName: PosHold braking rate
     // @Description: PosHold flight mode's rotation rate during braking in deg/sec

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -111,8 +111,8 @@ public:
         k_param_angle_max,
         k_param_gps_hdop_good,
         k_param_battery,
-        k_param_planck_angle_max,//k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
-        k_param_angle_rate_max,         // remove
+        k_param_planck_angle_max,       //k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
+        k_param_planck_angle_fs_to,         // remove
         k_param_rssi_range,             // unused, replaced by rssi_ library parameters
         k_param_rc_feel_rp,             // deprecated
         k_param_NavEKF,                 // deprecated - remove
@@ -408,7 +408,7 @@ public:
     AP_Int16        poshold_brake_rate;         // PosHold flight mode's rotation rate during braking in deg/sec
     AP_Int16        poshold_brake_angle_max;    // PosHold flight mode's max lean angle during braking in centi-degrees
 
-    //AP_Int16        planck_angle_max;    // Planck flight mode's max lean angle for checking high wind
+    AP_Int16        planck_angle_fs_to;    // Planck flight mode's max lean angle timeout for checking high wind
     
     // Waypoints
     //

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -111,7 +111,7 @@ public:
         k_param_angle_max,
         k_param_gps_hdop_good,
         k_param_battery,
-        k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
+        k_param_planck_angle_max,//k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
         k_param_angle_rate_max,         // remove
         k_param_rssi_range,             // unused, replaced by rssi_ library parameters
         k_param_rc_feel_rp,             // deprecated
@@ -407,6 +407,8 @@ public:
 
     AP_Int16        poshold_brake_rate;         // PosHold flight mode's rotation rate during braking in deg/sec
     AP_Int16        poshold_brake_angle_max;    // PosHold flight mode's max lean angle during braking in centi-degrees
+
+    //AP_Int16        planck_angle_max;    // Planck flight mode's max lean angle for checking high wind
     
     // Waypoints
     //

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -111,7 +111,7 @@ public:
         k_param_angle_max,
         k_param_gps_hdop_good,
         k_param_battery,
-        k_param_planck_angle_max,       //k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
+        k_param_planck_angle_max,       // Planck parameter, takes the slot of k_param_fs_batt_mah, which was not used/moved to AP_BattMonitor
         k_param_planck_angle_fs_to,     // remove
         k_param_failsafe_planck_angle,             // unused, replaced by rssi_ library parameters
         k_param_rc_feel_rp,             // deprecated

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -112,8 +112,8 @@ public:
         k_param_gps_hdop_good,
         k_param_battery,
         k_param_planck_angle_max,       //k_param_fs_batt_mah,            // unused - moved to AP_BattMonitor
-        k_param_planck_angle_fs_to,         // remove
-        k_param_rssi_range,             // unused, replaced by rssi_ library parameters
+        k_param_planck_angle_fs_to,     // remove
+        k_param_failsafe_planck_angle,             // unused, replaced by rssi_ library parameters
         k_param_rc_feel_rp,             // deprecated
         k_param_NavEKF,                 // deprecated - remove
         k_param_mission,                // mission library
@@ -408,7 +408,8 @@ public:
     AP_Int16        poshold_brake_rate;         // PosHold flight mode's rotation rate during braking in deg/sec
     AP_Int16        poshold_brake_angle_max;    // PosHold flight mode's max lean angle during braking in centi-degrees
 
-    AP_Int16        planck_angle_fs_to;    // Planck flight mode's max lean angle timeout for checking high wind
+    AP_Int8         failsafe_planck_angle; // Planck lean angle failsafe behavior
+    AP_Int32        planck_angle_fs_to;    // Planck flight mode's max lean angle timeout for checking high wind
     
     // Waypoints
     //

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -171,6 +171,12 @@
  #define FS_TERRAIN_TIMEOUT_MS          5000     // 5 seconds of missing terrain data will trigger failsafe (RTL)
 #endif
 
+// high lean angle failsafe
+#ifndef FS_LEAN_TIMEOUT_MS
+ #define FS_LEAN_TIMEOUT_MS          5000     // 5 seconds of high lean angle (PLANCKLAND)
+#endif
+
+
 #ifndef PREARM_DISPLAY_PERIOD
 # define PREARM_DISPLAY_PERIOD 30
 #endif
@@ -593,6 +599,10 @@
 #endif
 #ifndef ANGLE_RATE_MAX
  # define ANGLE_RATE_MAX            18000           // default maximum rotation rate in roll/pitch axis requested by angle controller used in stabilize, loiter, rtl, auto flight modes
+#endif
+
+#ifndef DEFAULT_PLANCK_ANGLE_MAX
+ # define DEFAULT_PLANCK_ANGLE_MAX         4500            // ANGLE_MAX parameters default value
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -602,7 +602,7 @@
 #endif
 
 #ifndef DEFAULT_PLANCK_ANGLE_MAX
- # define DEFAULT_PLANCK_ANGLE_MAX         4500            // ANGLE_MAX parameters default value
+ # define DEFAULT_PLANCK_ANGLE_MAX         1200            // PLANCK_ANGLE_MAX parameters default value
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -228,9 +228,9 @@ enum HarmonicNotchDynamicMode {
 #define FS_EKF_ACTION_LAND_EVEN_STABILIZE   3       // switch to Land mode on EKF failsafe even if in a manual flight mode like stabilize
 
 // Lean angle failsafe definitions (FS_PLANCK_ANGLE parameter)
-#define FS_PLANCK_ANGLE_DISABLED                            0
-#define FS_PLANCK_ANGLE_ENABLED_PLANCK_TRACK_PLANCK_LAND                  1
-#define FS_PLANCK_ANGLE_WARN                            2
+#define FS_PLANCK_ANGLE_DISABLED                          0
+#define FS_PLANCK_ANGLE_ENABLED_PLANCK_TRACK_PLANCK_LAND  1
+#define FS_PLANCK_ANGLE_WARN                              2
 
 // for mavlink SET_POSITION_TARGET messages
 #define MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE      ((1<<0) | (1<<1) | (1<<2))

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -227,6 +227,11 @@ enum HarmonicNotchDynamicMode {
 #define FS_EKF_ACTION_ALTHOLD               2       // switch to ALTHOLD mode on EKF failsafe
 #define FS_EKF_ACTION_LAND_EVEN_STABILIZE   3       // switch to Land mode on EKF failsafe even if in a manual flight mode like stabilize
 
+// Lean angle failsafe definitions (FS_PLANCK_ANGLE parameter)
+#define FS_PLANCK_ANGLE_DISABLED                            0
+#define FS_PLANCK_ANGLE_ENABLED_PLANCK_TRACK_PLANCK_LAND                  1
+#define FS_PLANCK_ANGLE_WARN                            2
+
 // for mavlink SET_POSITION_TARGET messages
 #define MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE      ((1<<0) | (1<<1) | (1<<2))
 #define MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE      ((1<<3) | (1<<4) | (1<<5))

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -325,7 +325,7 @@ void Copter::failsafe_lean_check(uint16_t duration_ms)
         failsafe.lean_high_time_ms = 0;
     }
 
-    bool timeout = uint16_t(AP_HAL::millis()-failsafe.lean_high_time_ms) > g.planck_angle_fs_to;
+    bool timeout = (AP_HAL::millis() - failsafe.lean_high_time_ms) > g.planck_angle_fs_to;
     bool trigger_event = valid_mode && timeout;
 
     // check for clearing of event

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -308,14 +308,14 @@ void Copter::gpsglitch_check()
 
 // executes lean-angle failsafe if lean angle is too high for longer than a set threshold
 // indicates the wind is too high to fly safely in planck mode
-void Copter::failsafe_lean_check(uint32_t duration_ms)
+void Copter::failsafe_lean_check(uint16_t duration_ms)
 {
     // trigger with X seconds of failures while in a PLANCK mode
     bool valid_mode = (control_mode == Mode::Number::PLANCKTRACK ||
                        control_mode == Mode::Number::PLANCKRTB ||
                        control_mode == Mode::Number::PLANCKLAND ||
                        control_mode == Mode::Number::PLANCKWINGMAN);
-    bool timeout = (duration_ms) > FS_LEAN_TIMEOUT_MS;
+    bool timeout = (duration_ms) > g.planck_angle_fs_to;
     bool trigger_event = valid_mode && timeout;
 
     // check for clearing of event
@@ -332,7 +332,7 @@ void Copter::failsafe_lean_check(uint32_t duration_ms)
 // terrain failsafe action
 void Copter::failsafe_lean_on_event()
 {
-    failsafe.terrain = true;
+    failsafe.lean = true;
     gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Lean angle high");
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_LEAN, LogErrorCode::FAILSAFE_OCCURRED);
 

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -362,7 +362,7 @@ void Copter::failsafe_lean_on_event()
                 desired_action = Failsafe_Action_None;
         }
 
-    // Conditions to deviate from FS_GCS_ENABLE parameter setting
+    // Conditions to deviate from FS_PLANCK_ANGLE_DISABLED parameter setting
     if (!motors->armed()) {
         desired_action = Failsafe_Action_None;
         gcs().send_text(MAV_SEVERITY_WARNING, "Lean Angle Failsafe");

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -308,7 +308,7 @@ void Copter::gpsglitch_check()
 
 // executes lean-angle failsafe if lean angle is too high for longer than a set threshold
 // indicates the wind is too high to fly safely in planck mode
-void Copter::failsafe_lean_check(uint16_t duration_ms)
+void Copter::failsafe_lean_check()
 {
     // trigger with X seconds of failures while in a PLANCK mode
     bool valid_mode = (control_mode == Mode::Number::PLANCKTRACK ||
@@ -325,7 +325,7 @@ void Copter::failsafe_lean_check(uint16_t duration_ms)
         failsafe.lean_high_time_ms = 0;
     }
 
-    bool timeout = (AP_HAL::millis() - failsafe.lean_high_time_ms) > g.planck_angle_fs_to;
+    bool timeout = (failsafe.lean_high_time_ms > 0) && ((AP_HAL::millis() - failsafe.lean_high_time_ms) > uint32_t(g.planck_angle_fs_to));
     bool trigger_event = valid_mode && timeout;
 
     // check for clearing of event

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1522,7 +1522,6 @@ protected:
 
     //if we want to land or transition to planck_land when we get back
     bool _land_when_ready = false;
-    uint32_t _high_lean_start_ms = 0; //time in ms when lean angle started being too high;
 };
 
 class ModePlanckRTB : public ModeGuided {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1522,6 +1522,7 @@ protected:
 
     //if we want to land or transition to planck_land when we get back
     bool _land_when_ready = false;
+    uint32_t _high_lean_start_ms = 0; //time in ms when lean angle started being too high;
 };
 
 class ModePlanckRTB : public ModeGuided {

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -193,8 +193,8 @@ void ModePlanckTracking::run() {
       }
     }
 
-    if (g.failsafe_planck_angle > 0){
-        copter.failsafe_lean_check(AP_HAL::millis() - _high_lean_start_ms);
+    if (g.failsafe_planck_angle != FS_PLANCK_ANGLE_DISABLED){
+        copter.failsafe_lean_check();
     }
     else if(copter.failsafe.lean > 0){
         copter.failsafe.lean = false;

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -193,15 +193,13 @@ void ModePlanckTracking::run() {
       }
     }
 
-    if (attitude_control->lean_angle()*100 > attitude_control->planck_lean_angle_max()){
-      if(_high_lean_start_ms<=0)
-      {
-        _high_lean_start_ms = AP_HAL::millis();
-      }
-      copter.failsafe_lean_check(AP_HAL::millis() - _high_lean_start_ms);
+    if (g.failsafe_planck_angle > 0){
+        copter.failsafe_lean_check(AP_HAL::millis() - _high_lean_start_ms);
     }
-    else{
-      _high_lean_start_ms = 0;
+    else if(copter.failsafe.lean > 0){
+        copter.failsafe.lean = false;
+        copter.failsafe.lean_high_time_ms = 0;
+        AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_LEAN, LogErrorCode::ERROR_RESOLVED);
     }
 
     //Run the guided mode controller

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -193,6 +193,18 @@ void ModePlanckTracking::run() {
       }
     }
 
+    if (attitude_control->lean_angle()*100 > attitude_control->lean_angle_max()){
+      if(_high_lean_start_ms<=0)
+      {
+        _high_lean_start_ms = AP_HAL::millis();
+      }
+      copter.failsafe_lean_check(AP_HAL::millis() - _high_lean_start_ms);
+    }
+    else{
+      _high_lean_start_ms = 0;
+    }
+
+
     //Run the guided mode controller
     ModeGuided::run(true); //use high-jerk
 }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -193,7 +193,7 @@ void ModePlanckTracking::run() {
       }
     }
 
-    if (attitude_control->lean_angle()*100 > attitude_control->lean_angle_max()){
+    if (attitude_control->lean_angle()*100 > attitude_control->planck_lean_angle_max()){
       if(_high_lean_start_ms<=0)
       {
         _high_lean_start_ms = AP_HAL::millis();
@@ -203,7 +203,6 @@ void ModePlanckTracking::run() {
     else{
       _high_lean_start_ms = 0;
     }
-
 
     //Run the guided mode controller
     ModeGuided::run(true); //use high-jerk

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -265,6 +265,9 @@ public:
     // Return tilt angle in degrees
     float lean_angle() const { return degrees(_thrust_angle); }
 
+    // Return configured planck tilt angle limit in centidegrees
+    float planck_lean_angle_max() const { return _aparm.planck_angle_max; }
+
     // Proportional controller with piecewise sqrt sections to constrain second derivative
     static float sqrt_controller(float error, float p, float second_ord_lim, float dt);
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -128,6 +128,7 @@ enum class LogErrorSubsystem : uint8_t {
     FAILSAFE_LEAK = 27,
     PILOT_INPUT = 28,
     FAILSAFE_VIBE = 29,
+    FAILSAFE_LEAN = 30,
 };
 
 // bizarrely this enumeration has lots of duplicate values, offering

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -104,6 +104,7 @@ public:
      */
     struct MultiCopter {
         AP_Int16 angle_max;
+        AP_Int16 planck_angle_max;
     };
 
 protected:

--- a/libraries/AP_Vehicle/ModeReason.h
+++ b/libraries/AP_Vehicle/ModeReason.h
@@ -53,4 +53,5 @@ enum class ModeReason : uint8_t {
   UNAVAILABLE,
   AUTOROTATION_START,
   AUTOROTATION_BAILOUT,
+  LEAN_FAILSAFE,
 };


### PR DESCRIPTION
This PR adds a failsafe for high tilt angle when in a planck tag tracking mode. It aims to trigger when apparent wind is high enough that the required tilt angle for steady hover risks keeping the tag near the edge/outside of the frame. The failsafe is triggered when the tilt angle is above a configurable threshold (PLANCK_ANGLE_MAX) for a configurable amount of time (PLANCK_ANG_FS_TO). Furthermore, this failsafe can be disabled, only give a warning when triggered, or perform a Planck Land when triggered. The default value of PLANCK_ANGLE_MAX is set to 1/4 of the field of view of the pi camera (48 deg). The new parameters are:

PLANCK_ANGLE_MAX  (centidegrees, default 1200)
PLANCK_ANG_FS_TO  (milliseconds, default 5000)
FS_ANGLE_ENABLE (0:Disabled,1: Enabled always Planck Track or Planck land, 2:Enabled Only Warn) (default is 0).
