### PR TITLE
I2c gpio battery

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -6,6 +6,7 @@
 #include "AP_BattMonitor_Sum.h"
 #include "AP_BattMonitor_FuelFlow.h"
 #include "AP_BattMonitor_FuelLevel_PWM.h"
+#include "AP_BattMonitor_Analog_GPIO.h"
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -146,6 +147,11 @@ AP_BattMonitor::init()
             case AP_BattMonitor_Params::BattMonitor_TYPE_FuelLevel_PWM:
                 drivers[instance] = new AP_BattMonitor_FuelLevel_PWM(*this, state[instance], _params[instance]);
                 break;
+            case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO:
+                drivers[instance] = new AP_BattMonitor_Analog_GPIO(*this, state[instance], _params[instance],
+                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL, AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR,
+                                                                                            100000, true, 20));
+                break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_NONE:
             default:
                 break;
@@ -253,7 +259,7 @@ AP_BattMonitor::read()
     }
 
     check_failsafes();
-    
+
     checkPoweringOff();
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -150,7 +150,7 @@ AP_BattMonitor::init()
             case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO:
                 drivers[instance] = new AP_BattMonitor_Analog_GPIO(*this, state[instance], _params[instance],
                                                                   hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL, AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR,
-                                                                                            100000, true, 20));
+                                                                                            100000, false, 20));
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_NONE:
             default:

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -149,8 +149,8 @@ AP_BattMonitor::init()
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO:
                 drivers[instance] = new AP_BattMonitor_Analog_GPIO(*this, state[instance], _params[instance],
-                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL, AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR,
-                                                                                            100000, false, 20));
+                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL, AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR,
+                                                                                            100000, true, 20));
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_NONE:
             default:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
@@ -1,0 +1,33 @@
+#include "AP_BattMonitor_Analog_GPIO.h"
+
+extern const AP_HAL::HAL& hal;
+
+AP_BattMonitor_Analog_GPIO::AP_BattMonitor_Analog_GPIO(AP_BattMonitor &mon,
+                                                       AP_BattMonitor::BattMonitor_State &mon_state,
+                                                       AP_BattMonitor_Params &params,
+                                                       AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+    : AP_BattMonitor_Analog(mon, mon_state, params), _dev(std::move(dev)) {
+
+}
+
+void AP_BattMonitor_Analog_GPIO::init(void) {
+    if (_dev) {
+        _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_Analog_GPIO::timer, void));
+    }
+    AP_BattMonitor_Analog::init();
+}
+
+void AP_BattMonitor_Analog_GPIO::read(void) {
+  //Read the analog status
+  AP_BattMonitor_Analog::read();
+}
+
+void AP_BattMonitor_Analog_GPIO::timer() {
+  //Read the state of the i2c device by reading one byte from register 0
+  uint8_t buf;
+  if(!_dev->read_registers(0, &buf, 1)) {
+    return;
+  }
+  //The state of the battery discharging is on GPIO 0
+  _is_using_battery = (bool)(buf & 0x01);
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
@@ -13,7 +13,7 @@ AP_BattMonitor_Analog_GPIO::AP_BattMonitor_Analog_GPIO(AP_BattMonitor &mon,
 
 void AP_BattMonitor_Analog_GPIO::init(void) {
     if (_dev) {
-        _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_Analog_GPIO::timer, void));
+        _dev->register_periodic_callback(500000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_Analog_GPIO::timer, void));
     }
     AP_BattMonitor_Analog::init();
 }
@@ -30,7 +30,7 @@ void AP_BattMonitor_Analog_GPIO::timer() {
     return;
   }
 
-  bool new_is_using_battery = (bool)(buf & 0x01);
+  bool new_is_using_battery = (bool)((buf & 0x01) == 0);
   if(!_is_using_battery && new_is_using_battery) {
     gcs().send_text(MAV_SEVERITY_CRITICAL, "Using battery power");
   } else if (_is_using_battery && !new_is_using_battery) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.cpp
@@ -1,4 +1,5 @@
 #include "AP_BattMonitor_Analog_GPIO.h"
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -28,6 +29,14 @@ void AP_BattMonitor_Analog_GPIO::timer() {
   if(!_dev->read_registers(0, &buf, 1)) {
     return;
   }
+
+  bool new_is_using_battery = (bool)(buf & 0x01);
+  if(!_is_using_battery && new_is_using_battery) {
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Using battery power");
+  } else if (_is_using_battery && !new_is_using_battery) {
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Using tether power");
+  }
+
   //The state of the battery discharging is on GPIO 0
-  _is_using_battery = (bool)(buf & 0x01);
+  _is_using_battery = new_is_using_battery;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "AP_BattMonitor_Analog.h"
+#include "AP_HAL/I2CDevice.h"
+
+#define AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL           0
+#define AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL           1
+#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR               0x49 //PCA9537
+#define AP_BATTMONITOR_ANALOG_GPIO_TIMEOUT_MICROS         5000000 // sensor becomes unhealthy if no successful readings for 5 seconds
+
+class AP_BattMonitor_Analog_GPIO : public AP_BattMonitor_Analog {
+public:
+    AP_BattMonitor_Analog_GPIO(AP_BattMonitor &mon,
+        AP_BattMonitor::BattMonitor_State &mon_state,
+        AP_BattMonitor_Params &params,
+        AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
+    void read() override;
+
+    void init(void) override;
+
+    bool get_is_using_battery() { return _is_using_battery; };
+
+private:
+  AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+  bool _is_using_battery = false;
+
+  void timer();
+};

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -25,6 +25,7 @@ public:
         BattMonitor_TYPE_Sum                        = 10,
         BattMonitor_TYPE_FuelFlow                   = 11,
         BattMonitor_TYPE_FuelLevel_PWM              = 12,
+        BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO = 13,
     };
 
     // low voltage sources (used for BATT_LOW_TYPE parameter)


### PR DESCRIPTION
[AVEM-201](https://planckaero.atlassian.net/browse/AVEM-201?atlOrigin=eyJpIjoiZTk0ZDJhNWMwZDFkNDdhMWE0MDFmMjFiMjgyMzkzMTkiLCJwIjoiaiJ9)

This PR introduces the `ANALOG_GPIO` battery monitor type, which is a derivative of the standard `ANALOG` type with the addition of a check on an i2c GPIO expander.  When the proper GPIO value is toggled, this battery monitor simply emits a GCS statustext indicating to the user that the system has switched from tether to battery power or vice-versa.