### PR TITLE
Planck copter 4.0.3 avem indago yaw

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -74,7 +74,8 @@ void ModePlanckTracking::run() {
               }
               //Some applications require a fixed yaw command when in PLANCKTRACK
               //If we are not in takeoff or landing, use the fixed yaw command from the GCS
-              else if(copter.flightmode == &copter.mode_plancktracking)
+              else if(copter.flightmode == &copter.mode_plancktracking
+                      && copter.flightmode->auto_yaw.mode() == AUTO_YAW_FIXED)
               {
                   yaw_cd = copter.flightmode->auto_yaw.yaw();
                   is_yaw_rate = false;

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -72,6 +72,13 @@ void ModePlanckTracking::run() {
                   yaw_cd = pilot_yaw_rate_cds;
                   is_yaw_rate = true;
               }
+              //Some applications require a fixed yaw command when in PLANCKTRACK
+              //If we are not in takeoff or landing, use the fixed yaw command from the GCS
+              else if(copter.flightmode == &copter.mode_plancktracking)
+              {
+                  yaw_cd = copter.flightmode->auto_yaw.yaw();
+                  is_yaw_rate = false;
+              }
 
               //Convert this to quaternions, yaw rates
               Quaternion q;


### PR DESCRIPTION
The purpose of this PR is to allow a user to set a yaw command to overwrite the ACE-generated yaw commands in certain condition. Specifically, the ACE-generated yaw commands are overridden when the current flight mode is "mode_plancktracking" and the auto_yaw mode is "AUTO_YAW_FIXED". Additionally, the yaw commands will be forced to yaw, not yaw rate. The yaw command will be sourced from the current flight mode's auto_yaw sub mode, ie: copter.flightmode->auto_yaw.yaw(), which is set when a user sends a MAV_CMD_CONDITION_YAW message. MAV_CMD_CONDITION_YAW message automatically changes the auto_yaw mode to AUTO_YAW_FIXED, so sending such a message while in mode_plancktracking will satisfy the conditions for the override. 

NOTES: ACE-generated yaw commands are not overridden when in mode_planckland, mode_planckrtb, or mode_planckwingman. Furthermore, they are not overridden during _mode_plancktracking _until_ MAV_CMD_CONDITION_YAW message has been sent _while in_ mode plancktracking. Additionally, they will not be overridden on takeoff _unless_ the user has sent a MAV_CMD_CONDITION_YAW during takeoff. Furthermore, the auto_yaw mode is changed when switching to another mode, so any user yaw commands will not persist when leaving and re-entering mode planck tracking. That is, whenever the aircraft enters mode_plancktracking, the yaw command will default to the ACE-generated yaw, until a MAV_CMD_CONDITION_YAW message is received. 

 
Currently, this is intended for use only on specific tethered application, but the author proposes it be considered for the master branch as well