### PR TITLE
Planck copter 4.0.3 avem indago tracking

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2,6 +2,8 @@
 
 #include "GCS_Mavlink.h"
 
+extern float g_scale_with_zoom;
+
 /*
  *  !!NOTE!!
  *
@@ -693,7 +695,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             bool relative_angle = is_positive(packet.param4);
             if (relative_angle) {
                 // apply zoom scaling only to the relative offset
-                scaled_p1 = scaled_p1 * GCS_MAVLINK::scale_with_zoom;
+                scaled_p1 = scaled_p1 * g_scale_with_zoom; //GCS_MAVLINK::scale_with_zoom;
             }
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 scaled_p1,

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -685,11 +685,17 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         // param2 : speed during change [deg per second]
         // param3 : direction (-1:ccw, +1:cw)
         // param4 : relative offset (1) or absolute angle (0)
-        if ((packet.param1 >= 0.0f)   &&
-            (packet.param1 <= 360.0f) &&
-            (is_zero(packet.param4) || is_equal(packet.param4,1.0f))) {
+        if ((packet.param1 < 0.0f) || (packet.param1 > 360.0f)) {
+            return MAV_RESULT_FAILED;
+        }
+        if (is_zero(packet.param4) || is_equal(packet.param4,1.0f)) {
+            float scaled_p1 = packet.param1;
+            // apply zoom scaling only to the relative offset
+            if (is_equal(packet.param4,1.0f)) {
+                scaled_p1 = scaled_p1 * GCS_MAVLINK::scale_with_zoom;
+            }
             copter.flightmode->auto_yaw.set_fixed_yaw(
-                packet.param1,
+                scaled_p1,
                 packet.param2,
                 (int8_t)packet.param3,
                 is_positive(packet.param4));
@@ -1321,7 +1327,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         copter.g2.toy_mode.handle_message(msg);
         break;
 #endif
-        
+
     default:
         handle_common_message(msg);
         break;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -683,11 +683,11 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 #endif
 
     case MAV_CMD_CONDITION_YAW:
-        // param1 : target angle [0-360]
+        // param1 : target angle [0-360)
         // param2 : speed during change [deg per second]
         // param3 : direction (-1:ccw, +1:cw)
         // param4 : relative offset (1) or absolute angle (0)
-        if ((packet.param1 < 0.0f) || (packet.param1 > 360.0f)) {
+        if ((packet.param1 < 0.0f) || (packet.param1 >= 360.0f)) {
             return MAV_RESULT_FAILED;
         }
         if (is_zero(packet.param4) || is_equal(packet.param4,1.0f)) {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -690,15 +690,16 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         }
         if (is_zero(packet.param4) || is_equal(packet.param4,1.0f)) {
             float scaled_p1 = packet.param1;
-            // apply zoom scaling only to the relative offset
-            if (is_equal(packet.param4,1.0f)) {
+            bool relative_angle = is_positive(packet.param4);
+            if (relative_angle) {
+                // apply zoom scaling only to the relative offset
                 scaled_p1 = scaled_p1 * GCS_MAVLINK::scale_with_zoom;
             }
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 scaled_p1,
                 packet.param2,
                 (int8_t)packet.param3,
-                is_positive(packet.param4));
+                relative_angle);
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2,8 +2,6 @@
 
 #include "GCS_Mavlink.h"
 
-extern float g_scale_with_zoom;
-
 /*
  *  !!NOTE!!
  *
@@ -693,9 +691,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         if (is_zero(packet.param4) || is_equal(packet.param4,1.0f)) {
             float scaled_p1 = packet.param1;
             bool relative_angle = is_positive(packet.param4);
-            if (relative_angle) {
+            AP_Mount *mount = AP::mount();
+            if ((relative_angle) && (mount != nullptr)) {
                 // apply zoom scaling only to the relative offset
-                scaled_p1 = scaled_p1 * g_scale_with_zoom; //GCS_MAVLINK::scale_with_zoom;
+                scaled_p1 = scaled_p1 * mount->mount_scale_with_zoom;
             }
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 scaled_p1,

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -499,7 +499,9 @@ void ModePosHold::run()
     pitch = constrain_float(pitch, -angle_max, angle_max);
 
     // call attitude controller
-    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
+    if (auto_yaw.mode() != AUTO_YAW_FIXED
+        || target_yaw_rate > 200 || target_yaw_rate < -200) { // range of target_yaw_rate is about -10000 to 10000
+        // Allow the pilot to override the yaw_condition command if the commanded yaw is above a threshold
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -499,9 +499,11 @@ void ModePosHold::run()
     pitch = constrain_float(pitch, -angle_max, angle_max);
 
     // call attitude controller
-    if (auto_yaw.mode() != AUTO_YAW_FIXED
-        || target_yaw_rate > 200 || target_yaw_rate < -200) { // range of target_yaw_rate is about -10000 to 10000
-        // Allow the pilot to override the yaw_condition command if the commanded yaw is above a threshold
+    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
+        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+        // the total range of target_yaw_rate is about -10000 to 10000,
+        // set the deadband to 200/10000 or 2% of the total range,
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -499,7 +499,13 @@ void ModePosHold::run()
     pitch = constrain_float(pitch, -angle_max, angle_max);
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
+    }
+    else {
+        // roll, pitch from pilot, yaw heading from auto_heading()
+        attitude_control->input_euler_angle_roll_pitch_yaw(roll, pitch, auto_yaw.yaw(), true);
+    }
 
     // call z-axis position controller
     pos_control->update_z_controller();

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -55,7 +55,13 @@ void ModeStabilize::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    }
+    else {
+        // roll, pitch from pilot, yaw heading from auto_heading()
+        attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, auto_yaw.yaw(), true);
+    }
 
     // output pilot's throttle
     attitude_control->set_throttle_out(get_pilot_desired_throttle(),

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -55,7 +55,9 @@ void ModeStabilize::run()
     }
 
     // call attitude controller
-    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
+    if (auto_yaw.mode() != AUTO_YAW_FIXED
+        || target_yaw_rate > 200 || target_yaw_rate < -200) { // range of target_yaw_rate is about -10000 to 10000
+        // Allow the pilot to override the yaw_condition command if the commanded yaw is above a threshold
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -55,9 +55,11 @@ void ModeStabilize::run()
     }
 
     // call attitude controller
-    if (auto_yaw.mode() != AUTO_YAW_FIXED
-        || target_yaw_rate > 200 || target_yaw_rate < -200) { // range of target_yaw_rate is about -10000 to 10000
-        // Allow the pilot to override the yaw_condition command if the commanded yaw is above a threshold
+    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
+        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+        // the total range of target_yaw_rate is about -10000 to 10000,
+        // set the deadband to 200/10000 or 2% of the total range,
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -72,7 +72,13 @@ void ModeStabilize_Heli::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    }
+    else {
+        // roll, pitch from pilot, yaw heading from auto_heading()
+        attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, auto_yaw.yaw(), true);
+    }
 
     // output pilot's throttle - note that TradHeli does not used angle-boost
     attitude_control->set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -72,13 +72,7 @@ void ModeStabilize_Heli::run()
     }
 
     // call attitude controller
-    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
-    }
-    else {
-        // roll, pitch from pilot, yaw heading from auto_heading()
-        attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, auto_yaw.yaw(), true);
-    }
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
 
     // output pilot's throttle - note that TradHeli does not used angle-boost
     attitude_control->set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -424,6 +424,9 @@ void AP_Mount::init()
         }
     }
 
+    // start with scaling disabled
+    mount_scale_with_zoom = 1.0;
+
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -132,6 +132,8 @@ public:
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 
+    float mount_scale_with_zoom;
+
 protected:
 
     static AP_Mount *_singleton;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,4 +1,4 @@
-#include "AP_Mount_Alexmos.h"
+﻿#include "AP_Mount_Alexmos.h"
 #include <AP_GPS/AP_GPS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
@@ -41,6 +41,12 @@ void AP_Mount_Alexmos::update()
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
             control_axis(_angle_ef_target_rad, false);
+
+//            if (get_control_mode(_state._yaw_input_mode) == AP_MOUNT_ALEXMOS_MODE_SPEED) {
+                get_angles_ext();
+                _angle_ef_target_rad.z = -_current_angle.z/20.0;
+//            }
+
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
@@ -162,7 +168,8 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
-    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
+//    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
+    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_SPEED;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);
@@ -246,9 +253,9 @@ void AP_Mount_Alexmos::parse_body()
             // The yaw angle reported by the IMU (angle_yaw) is very unreliable
             // so use the body frame angle (stator_rotor_angle_yaw) unless
             // the user specifically requests it (AP_Mount::Input_Mode_Angle_Absolute_Frame)
-            if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
+//            if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
                 _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw);
-            }
+//            }
             break;
 
         case CMD_READ_PARAMS:

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -41,12 +41,6 @@ void AP_Mount_Alexmos::update()
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
             control_axis(_angle_ef_target_rad, false);
-
-//            if (get_control_mode(_state._yaw_input_mode) == AP_MOUNT_ALEXMOS_MODE_SPEED) {
-                get_angles_ext();
-                _angle_ef_target_rad.z = -_current_angle.z/20.0;
-//            }
-
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
@@ -169,13 +163,14 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
 //    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
-    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_SPEED;
+//    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_SPEED;
+    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_NO_CONTROL;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
-    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(target_deg.z);
-    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
+//    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(target_deg.z);
+//    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -162,15 +162,13 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
-//    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
-//    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_SPEED;
     outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_NO_CONTROL;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
-//    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(target_deg.z);
-//    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
+    // Deliberately not commanding target_deg.z (yaw) because we are relying on Alexmos'
+    // follow yaw mode.  Explicitly commanding yaw interferes with follow yaw mode.
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 
@@ -248,9 +246,9 @@ void AP_Mount_Alexmos::parse_body()
             // The yaw angle reported by the IMU (angle_yaw) is very unreliable
             // so use the body frame angle (stator_rotor_angle_yaw) unless
             // the user specifically requests it (AP_Mount::Input_Mode_Angle_Absolute_Frame)
-//            if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
+            if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
                 _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw);
-//            }
+            }
             break;
 
         case CMD_READ_PARAMS:

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -59,7 +59,7 @@
 
 #define AP_MOUNT_ALEXMOS_SPEED 30 // degree/s2
 
-#define VALUE_TO_DEGREE(d) ((float)((d * 720) >> 15))
+#define VALUE_TO_DEGREE(d) ((float)((d * 0.02197265625f)))
 #define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.02197265625f)))
 #define DEGREE_PER_SEC_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.1220740379f)))
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -59,8 +59,11 @@
 
 #define AP_MOUNT_ALEXMOS_SPEED 30 // degree/s2
 
-#define VALUE_TO_DEGREE(d) ((float)((d * 0.02197265625f)))
-#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.02197265625f)))
+// degree mapped to range 0.0-1.0, with fixed point 14-bit fraction
+//#define VALUE_TO_DEGREE(d) ((float)((d * 0.02197265625f)))
+#define VALUE_TO_DEGREE(d) ((float)(d)*(360.0f/16384.0f))
+//#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.02197265625f)))
+#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(16384.0f/360.0f)))
 #define DEGREE_PER_SEC_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.1220740379f)))
 
 class AP_Mount_Alexmos : public AP_Mount_Backend

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -60,9 +60,7 @@
 #define AP_MOUNT_ALEXMOS_SPEED 30 // degree/s2
 
 // degree mapped to range 0.0-1.0, with fixed point 14-bit fraction
-//#define VALUE_TO_DEGREE(d) ((float)((d * 0.02197265625f)))
 #define VALUE_TO_DEGREE(d) ((float)(d)*(360.0f/16384.0f))
-//#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.02197265625f)))
 #define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(16384.0f/360.0f)))
 #define DEGREE_PER_SEC_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.1220740379f)))
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -278,8 +278,6 @@ public:
 
     MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
 
-    //float scale_with_zoom = 1.0;
-
 protected:
 
     virtual bool in_hil_mode() const { return false; }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -278,6 +278,8 @@ public:
 
     MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
 
+    //float scale_with_zoom = 1.0;
+
 protected:
 
     virtual bool in_hil_mode() const { return false; }
@@ -417,10 +419,6 @@ protected:
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_fence_enable(const mavlink_command_long_t &packet);
 
-    // reduce effect of vehicle Yaw and gimbal pitch with increasing camera zoom
-    MAV_RESULT handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet);
-    float scale_with_zoom = 1.0;
-    
     void handle_optical_flow(const mavlink_message_t &msg);
 
     MAV_RESULT handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet);
@@ -452,6 +450,9 @@ protected:
 
 private:
 
+    // reduce effect of vehicle Yaw and gimbal pitch with increasing camera zoom
+    MAV_RESULT handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet);
+    
     void log_mavlink_stats();
 
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -417,6 +417,10 @@ protected:
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_fence_enable(const mavlink_command_long_t &packet);
 
+    // reduce effect of vehicle Yaw and gimbal pitch with increasing camera zoom
+    MAV_RESULT handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet);
+    float scale_with_zoom = 1.0;
+    
     void handle_optical_flow(const mavlink_message_t &msg);
 
     MAV_RESULT handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -39,8 +39,6 @@
 #include <AP_OpticalFlow/OpticalFlow.h>
 #include <AP_Baro/AP_Baro.h>
 
-float g_scale_with_zoom = 1.0f;
-
 #include <stdio.h>
 
 #if HAL_RCINPUT_WITH_AP_RADIO
@@ -3694,9 +3692,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
 
     // scale the pitch, roll, yaw with zoom
     mavlink_command_long_t scaled_packet = packet;
-    scaled_packet.param1 = scaled_packet.param1 * g_scale_with_zoom;
-    scaled_packet.param2 = scaled_packet.param2 * g_scale_with_zoom;
-    scaled_packet.param3 = scaled_packet.param3 * g_scale_with_zoom;
+    scaled_packet.param1 = scaled_packet.param1 * mount->mount_scale_with_zoom;
+    scaled_packet.param2 = scaled_packet.param2 * mount->mount_scale_with_zoom;
+    scaled_packet.param3 = scaled_packet.param3 * mount->mount_scale_with_zoom;
     return mount->handle_command_long(scaled_packet);
 }
 
@@ -3727,7 +3725,12 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t 
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet)
 {
-    g_scale_with_zoom = packet.param1;
+    AP_Mount *mount = AP::mount();
+    if (mount == nullptr) {
+        return MAV_RESULT_UNSUPPORTED;
+    }
+
+    mount->mount_scale_with_zoom = packet.param1;
     return MAV_RESULT_ACCEPTED;
 }
 
@@ -3757,7 +3760,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         result = handle_command_do_fence_enable(packet);
         break;
 
-#define MAV_CMD_DO_SCALE_WITH_ZOOM 40003
     case MAV_CMD_DO_SCALE_WITH_ZOOM:
         result = handle_command_do_scale_with_zoom(packet);
         break;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3692,11 +3692,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
 
     // scale the pitch, roll, yaw with zoom
     mavlink_command_long_t scaled_packet = packet;
-    if (!is_equal(GCS_MAVLINK::scale_with_zoom, 1.0f)) {
-        scaled_packet.param1 = scaled_packet.param1 * GCS_MAVLINK::scale_with_zoom;
-        scaled_packet.param2 = scaled_packet.param2 * GCS_MAVLINK::scale_with_zoom;
-        scaled_packet.param3 = scaled_packet.param3 * GCS_MAVLINK::scale_with_zoom;
-    }
+    scaled_packet.param1 = scaled_packet.param1 * scale_with_zoom;
+    scaled_packet.param2 = scaled_packet.param2 * scale_with_zoom;
+    scaled_packet.param3 = scaled_packet.param3 * scale_with_zoom;
     return mount->handle_command_long(scaled_packet);
 }
 
@@ -3727,13 +3725,13 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t 
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet)
 {
-    GCS_MAVLINK::scale_with_zoom = packet.param1;
+    scale_with_zoom = packet.param1;
 
-    if (GCS_MAVLINK::scale_with_zoom < 0.0f) {
-        GCS_MAVLINK::scale_with_zoom = 0.0f;
+    if (scale_with_zoom < 0.0f) {
+        scale_with_zoom = 0.0f;
     }
-    else if (GCS_MAVLINK::scale_with_zoom > 1.0f) {
-        GCS_MAVLINK::scale_with_zoom = 1.0f;
+    else if (scale_with_zoom > 1.0f) {
+        scale_with_zoom = 1.0f;
     }
 
     return MAV_RESULT_ACCEPTED;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -162,9 +162,6 @@ bool GCS_MAVLINK::init(uint8_t instance)
         status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
     }
 
-    // default value disables scaling
-    //scale_with_zoom = 1.0f;
-
     return true;
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -39,6 +39,8 @@
 #include <AP_OpticalFlow/OpticalFlow.h>
 #include <AP_Baro/AP_Baro.h>
 
+float g_scale_with_zoom = 1.0f;
+
 #include <stdio.h>
 
 #if HAL_RCINPUT_WITH_AP_RADIO
@@ -159,6 +161,9 @@ bool GCS_MAVLINK::init(uint8_t instance)
         // after experiments with MAVLink2
         status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
     }
+
+    // default value disables scaling
+    //scale_with_zoom = 1.0f;
 
     return true;
 }
@@ -3692,9 +3697,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
 
     // scale the pitch, roll, yaw with zoom
     mavlink_command_long_t scaled_packet = packet;
-    scaled_packet.param1 = scaled_packet.param1 * scale_with_zoom;
-    scaled_packet.param2 = scaled_packet.param2 * scale_with_zoom;
-    scaled_packet.param3 = scaled_packet.param3 * scale_with_zoom;
+    scaled_packet.param1 = scaled_packet.param1 * g_scale_with_zoom;
+    scaled_packet.param2 = scaled_packet.param2 * g_scale_with_zoom;
+    scaled_packet.param3 = scaled_packet.param3 * g_scale_with_zoom;
     return mount->handle_command_long(scaled_packet);
 }
 
@@ -3725,15 +3730,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t 
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet)
 {
-    scale_with_zoom = packet.param1;
-
-    if (scale_with_zoom < 0.0f) {
-        scale_with_zoom = 0.0f;
-    }
-    else if (scale_with_zoom > 1.0f) {
-        scale_with_zoom = 1.0f;
-    }
-
+    g_scale_with_zoom = packet.param1;
     return MAV_RESULT_ACCEPTED;
 }
 


### PR DESCRIPTION
The changes in this pull request support smooth gimbal steering and tracking using an Alexmos gimbal.  Specifically it includes:

- Scaling vehicle yaw and gimbal commands in ArduPilot based on the current zoom level reported by the camera (high zoom -> scale down yaw and gimbal commands, and vice versa)
- Allowing MAV_CMD_CONDITION_YAW commands to control the vehicle yaw in stabilize and position hold flight modes to support testing
- Putting the alexmos gimbal in an appropriate mode to allow Alexmos' built in follow yaw mode to work properly
- Fixing a bug in the exisiting Alexmos ardupilot interface that artificially limited the resolution of reported gimbal angles