### PR TITLE
Improved Tracking - Mount leads vehicle when tracking

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -625,6 +625,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
             return GCS_MAVLINK::handle_command_mount(packet);
         }
+        break;
+    case MAV_CMD_DO_MOUNT_CONFIGURE:
+        return GCS_MAVLINK::handle_command_mount(packet);
+        break;
     default:
         break;
     }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -610,22 +610,25 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_i
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t &packet)
 {
-    // if the mount doesn't do pan control then yaw the entire vehicle instead:
+    AP_Mount *mount = AP::mount();
+    // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (packet.command) {
-#if MOUNT == ENABLED
     case MAV_CMD_DO_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control()) {
+        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 (float)packet.param3 * 0.01f,
                 0.0f,
-                0,0);
+                0,
+                0);
         }
-        break;
-#endif
+        else {
+            mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
+            return GCS_MAVLINK::handle_command_mount(packet);
+        }
     default:
         break;
     }
-    return GCS_MAVLINK::handle_command_mount(packet);
+    return MAV_RESULT_ACCEPTED;
 }
 
 bool GCS_MAVLINK_Copter::allow_disarm() const
@@ -681,6 +684,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 #endif
 
     case MAV_CMD_CONDITION_YAW:
+    {
+        AP_Mount *mount = AP::mount();
+
+        // switch gimbal YAW follow mode upon a vehicle YAW command
+        mount->mount_yaw_follow_mode = AP_Mount::gimbal_yaw_follows_vehicle;
+
         // param1 : target angle [0-360)
         // param2 : speed during change [deg per second]
         // param3 : direction (-1:ccw, +1:cw)
@@ -691,7 +700,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         if (is_zero(packet.param4) || is_equal(packet.param4,1.0f)) {
             float scaled_p1 = packet.param1;
             bool relative_angle = is_positive(packet.param4);
-            AP_Mount *mount = AP::mount();
             if ((relative_angle) && (mount != nullptr)) {
                 // apply zoom scaling only to the relative offset
                 scaled_p1 = scaled_p1 * mount->mount_scale_with_zoom;
@@ -704,6 +712,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;
+    }
 
     case MAV_CMD_DO_CHANGE_SPEED:
         // param1 : unused
@@ -900,11 +909,11 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 
 void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)
 {
+    AP_Mount *mount = AP::mount();
+    // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (msg.msgid) {
-#if MOUNT == ENABLED
     case MAVLINK_MSG_ID_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control()) {
-            // if the mount doesn't do pan control then yaw the entire vehicle instead:
+        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 mavlink_msg_mount_control_get_input_c(&msg) * 0.01f,
                 0.0f,
@@ -913,9 +922,11 @@ void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)
 
             break;
         }
-#endif
+        else {
+            mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
+            GCS_MAVLINK::handle_mount_message(msg);
+        }
     }
-    GCS_MAVLINK::handle_mount_message(msg);
 }
 
 void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -89,14 +89,7 @@ void ModePosHold::run()
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max());
 
     // get pilot's desired yaw rate, or let the gimbal steer the vehicle
-    AP_Mount *mount = AP::mount();
-    float target_yaw_rate;
-    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        target_yaw_rate = mount->get_follow_yaw_rate();
-    }
-    else {
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-    }
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot desired climb rate (for alt-hold mode and take-off)
     float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
@@ -505,12 +498,34 @@ void ModePosHold::run()
     roll = constrain_float(roll, -angle_max, angle_max);
     pitch = constrain_float(pitch, -angle_max, angle_max);
 
-    // call attitude controller
-    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
-        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+    AP_Mount *mount = AP::mount();
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        float angle_deg;
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
         // the total range of target_yaw_rate is about -10000 to 10000,
         // set the deadband to 200/10000 or 2% of the total range,
-        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
+        if ((target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+            angle_deg = target_yaw_rate/1000.0f;
+        }
+        else {
+            angle_deg = mount->get_follow_yaw_rate();
+        }
+        int8_t direction = 1;
+        bool relative_angle = true;
+        if (angle_deg < 0.0f) {
+            angle_deg = -angle_deg;
+            direction = -1;
+        }
+        // update auto_yaw private variable _fixed_yaw
+        copter.flightmode->auto_yaw.set_fixed_yaw(
+            angle_deg,
+            0, // use default angle change rate
+            direction,
+            relative_angle);
+    }
+
+    // call attitude controller
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -92,7 +92,7 @@ void ModePosHold::run()
     AP_Mount *mount = AP::mount();
     float target_yaw_rate;
     if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        target_yaw_rate = mount->get_yaw_rate();
+        target_yaw_rate = mount->get_follow_yaw_rate();
     }
     else {
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -88,8 +88,15 @@ void ModePosHold::run()
     float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max());
 
-    // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    // get pilot's desired yaw rate, or let the gimbal steer the vehicle
+    AP_Mount *mount = AP::mount();
+    float target_yaw_rate;
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        target_yaw_rate = mount->get_yaw_rate();
+    }
+    else {
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    }
 
     // get pilot desired climb rate (for alt-hold mode and take-off)
     float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -54,12 +54,34 @@ void ModeStabilize::run()
         break;
     }
 
-    // call attitude controller
-    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
-        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+    AP_Mount *mount = AP::mount();
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        float angle_deg;
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
         // the total range of target_yaw_rate is about -10000 to 10000,
         // set the deadband to 200/10000 or 2% of the total range,
-        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
+        if ((target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+            angle_deg = target_yaw_rate/1000.0f;
+        }
+        else {
+            angle_deg = mount->get_follow_yaw_rate();
+        }
+        int8_t direction = 1;
+        bool relative_angle = true;
+        if (angle_deg < 0.0f) {
+            angle_deg = -angle_deg;
+            direction = -1;
+        }
+        // update auto_yaw private variable _fixed_yaw
+        copter.flightmode->auto_yaw.set_fixed_yaw(
+            angle_deg,
+            0, // use default angle change rate
+            direction,
+            relative_angle);
+    }
+
+    // call attitude controller
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -55,7 +55,17 @@ void ModeStabilize::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
+        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+        // the total range of target_yaw_rate is about -10000 to 10000,
+        // set the deadband to 200/10000 or 2% of the total range,
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    }
+    else {
+        // roll, pitch from pilot, yaw heading from auto_heading()
+        attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, auto_yaw.yaw(), true);
+    }
 
     // output pilot's throttle
     attitude_control->set_throttle_out(get_pilot_desired_throttle(),

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -18,7 +18,6 @@ bool ModeStabilize_Heli::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeStabilize_Heli::run()
 {
-    AP_mount *mount = AP::mount();
     float target_roll, target_pitch;
     float target_yaw_rate;
     float pilot_throttle_scaled;
@@ -29,7 +28,7 @@ void ModeStabilize_Heli::run()
     // convert pilot input to lean angles
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 
-    // get pilot's desired yaw rate, or let the gimbal steer the vehicle
+    // get pilot's desired yaw rate
     target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot's desired throttle

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -18,6 +18,7 @@ bool ModeStabilize_Heli::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeStabilize_Heli::run()
 {
+    AP_mount *mount = AP::mount();
     float target_roll, target_pitch;
     float target_yaw_rate;
     float pilot_throttle_scaled;
@@ -28,8 +29,14 @@ void ModeStabilize_Heli::run()
     // convert pilot input to lean angles
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 
-    // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    // get pilot's desired yaw rate, or let the gimbal steer the vehicle
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        target_yaw_rate = mount->get_yaw_rate();
+    }
+    else {
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    }
+
 
     // get pilot's desired throttle
     pilot_throttle_scaled = copter.input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -31,7 +31,7 @@ void ModeStabilize_Heli::run()
 
     // get pilot's desired yaw rate, or let the gimbal steer the vehicle
     if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        target_yaw_rate = mount->get_yaw_rate();
+        target_yaw_rate = mount->get_follow_yaw_rate();
     }
     else {
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -30,13 +30,7 @@ void ModeStabilize_Heli::run()
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // get pilot's desired yaw rate, or let the gimbal steer the vehicle
-    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        target_yaw_rate = mount->get_follow_yaw_rate();
-    }
-    else {
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-    }
-
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot's desired throttle
     pilot_throttle_scaled = copter.input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -568,7 +568,7 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
 }
 
 
-#define VEHICLE_YAW_SCALE 0.1f
+#define VEHICLE_YAW_SCALE 1.0f
 float AP_Mount::get_follow_yaw_rate()
 {
     return VEHICLE_YAW_SCALE * yaw_encoder_readback;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -427,6 +427,11 @@ void AP_Mount::init()
     // start with scaling disabled
     mount_scale_with_zoom = 1.0;
 
+    AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
+
+    // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
+    AP_Mount::mount_yaw_follow_mode = gimbal_yaw_follows_vehicle;
+
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 
@@ -561,6 +566,14 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
     // send command to backend
     _backends[instance]->set_angle_targets(roll, tilt, pan);
 }
+
+
+#define VEHICLE_YAW_SCALE 0.1f
+float AP_Mount::get_yaw_rate()
+{
+    return VEHICLE_YAW_SCALE * yaw_encoder_readback;
+}
+
 
 MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_long_t &packet)
 {

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -569,7 +569,7 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
 
 
 #define VEHICLE_YAW_SCALE 0.1f
-float AP_Mount::get_yaw_rate()
+float AP_Mount::get_follow_yaw_rate()
 {
     return VEHICLE_YAW_SCALE * yaw_encoder_readback;
 }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -424,6 +424,9 @@ void AP_Mount::init()
         }
     }
 
+    // start with scaling disabled
+    mount_scale_with_zoom = 1.0;
+
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -134,6 +134,14 @@ public:
 
     float mount_scale_with_zoom;
 
+    float yaw_encoder_readback;
+    enum MountYawFollowMode {
+        gimbal_yaw_follows_vehicle = 0,
+        vehicle_yaw_follows_gimbal = 1
+    };
+    MountYawFollowMode mount_yaw_follow_mode;
+    float get_yaw_rate();
+
 protected:
 
     static AP_Mount *_singleton;

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -134,15 +134,17 @@ public:
 
     float mount_scale_with_zoom;
 
-    float yaw_encoder_readback;
     enum MountYawFollowMode {
         gimbal_yaw_follows_vehicle = 0,
         vehicle_yaw_follows_gimbal = 1
     };
     MountYawFollowMode mount_yaw_follow_mode;
-    float get_yaw_rate();
+
+    float get_follow_yaw_rate();
 
 protected:
+
+    float yaw_encoder_readback;
 
     static AP_Mount *_singleton;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -132,6 +132,8 @@ public:
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 
+    float mount_scale_with_zoom;
+
 protected:
 
     static AP_Mount *_singleton;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -42,29 +42,6 @@ void AP_Mount_Alexmos::update()
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
         {
 #define GIMBAL_YAW_SCALE (1.0f/20.0f)
-            /*
-#define VEHICLE_YAW_SCALE 0.1f
-            if (AP_Mount::mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)
-            {
-                // assume gimbal angles are set by by a MOUNT_CONTROL message from GCS
-                // move copter's YAW in same direction as gimbal, to keep the payload centered
-                int8_t direction = 0;
-                bool relative_angle = true;
-                if (_current_angle.z < 0.0f) {
-                    direction = -1;
-                    _current_angle.z = -_current_angle.z;
-                }
-                else {
-                    direction = 1;
-                }
-                float angle_deg = VEHICLE_YAW_SCALE * _current_angle.z;
-                copter.flightmode->auto_yaw.set_fixed_yaw(
-                    angle_deg,
-                    0.0f, // use default rate
-                    direction,
-                    relative_angle);
-            }
-            */
             AP_Mount *mount = AP::mount();
             if (mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
             {
@@ -197,7 +174,10 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
-    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
+    // Always setting the yaw mode to be speed rather than angles, so the current mavlinkVSM will work as is.
+    // The pilot view button won't center the mount yaw until we update the mavlinkVSM and set the mode_yaw
+    // back to be under GCS control via the MAV_CMD_DO_MOUNT_CONFIGURE command
+    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_SPEED;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -23,6 +23,7 @@ void AP_Mount_Alexmos::update()
         return;
     }
 
+    get_angles_ext();
     read_incoming(); // read the incoming messages from the gimbal
 
     // update based on mount mode
@@ -39,9 +40,42 @@ void AP_Mount_Alexmos::update()
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+        {
+#define GIMBAL_YAW_SCALE (1.0f/20.0f)
+            /*
+#define VEHICLE_YAW_SCALE 0.1f
+            if (AP_Mount::mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)
+            {
+                // assume gimbal angles are set by by a MOUNT_CONTROL message from GCS
+                // move copter's YAW in same direction as gimbal, to keep the payload centered
+                int8_t direction = 0;
+                bool relative_angle = true;
+                if (_current_angle.z < 0.0f) {
+                    direction = -1;
+                    _current_angle.z = -_current_angle.z;
+                }
+                else {
+                    direction = 1;
+                }
+                float angle_deg = VEHICLE_YAW_SCALE * _current_angle.z;
+                copter.flightmode->auto_yaw.set_fixed_yaw(
+                    angle_deg,
+                    0.0f, // use default rate
+                    direction,
+                    relative_angle);
+            }
+            */
+            AP_Mount *mount = AP::mount();
+            if (mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
+            {
+                // use yaw encoder to move yaw with the vehicle
+                _angle_ef_target_rad.z = -_current_angle.z * GIMBAL_YAW_SCALE;
+            }
+
+            // yaw angle (_current_angle.z) when gimbal follows the vehicle
             control_axis(_angle_ef_target_rad, false);
-            break;
+        }
+        break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING:
@@ -159,16 +193,17 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     if (!target_in_degrees) {
         target_deg *= RAD_TO_DEG;
     }
+
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
-    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_NO_CONTROL;
+    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
-    // Deliberately not commanding target_deg.z (yaw) because we are relying on Alexmos'
-    // follow yaw mode.  Explicitly commanding yaw interferes with follow yaw mode.
+    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(target_deg.z);
+    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 
@@ -234,6 +269,7 @@ void AP_Mount_Alexmos::parse_body()
             break;
 
         case CMD_GET_ANGLES_EXT:
+        {
             _current_angle.x = VALUE_TO_DEGREE(_buffer.angles_ext.angle_roll);
             _current_angle.y = VALUE_TO_DEGREE(_buffer.angles_ext.angle_pitch);
             _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw);
@@ -249,7 +285,12 @@ void AP_Mount_Alexmos::parse_body()
             if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
                 _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw);
             }
-            break;
+
+            // make yaw encoder value visible outside the AP_Mount class
+            AP_Mount *mount = AP::mount();
+            mount->yaw_encoder_readback = _current_angle.z;
+        }
+        break;
 
         case CMD_READ_PARAMS:
             _param_read_once = true;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,4 +1,4 @@
-#include "AP_Mount_Alexmos.h"
+﻿#include "AP_Mount_Alexmos.h"
 #include <AP_GPS/AP_GPS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
@@ -162,13 +162,13 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode_roll = get_control_mode(_state._roll_input_mode);
     outgoing_buffer.angle_speed.mode_pitch = get_control_mode(_state._pitch_input_mode);
-    outgoing_buffer.angle_speed.mode_yaw = get_control_mode(_state._yaw_input_mode);
+    outgoing_buffer.angle_speed.mode_yaw = AP_MOUNT_ALEXMOS_MODE_NO_CONTROL;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(target_deg.y);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
-    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(target_deg.z);
-    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
+    // Deliberately not commanding target_deg.z (yaw) because we are relying on Alexmos'
+    // follow yaw mode.  Explicitly commanding yaw interferes with follow yaw mode.
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -59,8 +59,9 @@
 
 #define AP_MOUNT_ALEXMOS_SPEED 30 // degree/s2
 
-#define VALUE_TO_DEGREE(d) ((float)((d * 720) >> 15))
-#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.02197265625f)))
+// degree mapped to range 0.0-1.0, with fixed point 14-bit fraction
+#define VALUE_TO_DEGREE(d) ((float)(d)*(360.0f/16384.0f))
+#define DEGREE_TO_VALUE(d) ((int16_t)((float)(d)*(16384.0f/360.0f)))
 #define DEGREE_PER_SEC_TO_VALUE(d) ((int16_t)((float)(d)*(1.0f/0.1220740379f)))
 
 class AP_Mount_Alexmos : public AP_Mount_Backend

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -448,6 +448,9 @@ protected:
 
 private:
 
+    // reduce effect of vehicle Yaw and gimbal pitch with increasing camera zoom
+    MAV_RESULT handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet);
+    
     void log_mavlink_stats();
 
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3689,7 +3689,13 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
     if (mount == nullptr) {
         return MAV_RESULT_UNSUPPORTED;
     }
-    return mount->handle_command_long(packet);
+
+    // scale the pitch, roll, yaw with zoom
+    mavlink_command_long_t scaled_packet = packet;
+    scaled_packet.param1 = scaled_packet.param1 * mount->mount_scale_with_zoom;
+    scaled_packet.param2 = scaled_packet.param2 * mount->mount_scale_with_zoom;
+    scaled_packet.param3 = scaled_packet.param3 * mount->mount_scale_with_zoom;
+    return mount->handle_command_long(scaled_packet);
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t &packet)
@@ -3717,6 +3723,16 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t 
     return MAV_RESULT_ACCEPTED;
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_do_scale_with_zoom(const mavlink_command_long_t &packet)
+{
+    AP_Mount *mount = AP::mount();
+    if (mount == nullptr) {
+        return MAV_RESULT_UNSUPPORTED;
+    }
+
+    mount->mount_scale_with_zoom = packet.param1;
+    return MAV_RESULT_ACCEPTED;
+}
 
 MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
@@ -3742,6 +3758,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
 
     case MAV_CMD_DO_FENCE_ENABLE:
         result = handle_command_do_fence_enable(packet);
+        break;
+
+    case MAV_CMD_DO_SCALE_WITH_ZOOM:
+        result = handle_command_do_scale_with_zoom(packet);
         break;
 
     case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:


### PR DESCRIPTION
- The mount now leads the vehicle when tracking.  This results in a much more stable tracking feedback loop.  The vehicle yaws to follow.
- The mount also leads the vehicle when the user explicitly sends mount yaw commands
- The vehicle still leads the mount when the user sends a condition yaw command.  The mount has a feedback loop that keeps it pointed straight forward (with a certain lag).