### PR TITLE
Coordinated mount and vehicle yaw steering

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -613,8 +613,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
     AP_Mount *mount = AP::mount();
     // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (packet.command) {
-    case MAV_CMD_DO_MOUNT_CONTROL:
 #if MOUNT == ENABLED
+    case MAV_CMD_DO_MOUNT_CONTROL:
         if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 (float)packet.param3 * 0.01f,
@@ -625,8 +625,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-#endif
         break;
+#endif
     default:
         break;
     }
@@ -918,8 +918,8 @@ void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)
     AP_Mount *mount = AP::mount();
     // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (msg.msgid) {
-    case MAVLINK_MSG_ID_MOUNT_CONTROL:
 #if MOUNT == ENABLED
+    case MAVLINK_MSG_ID_MOUNT_CONTROL:
         if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 mavlink_msg_mount_control_get_input_c(&msg) * 0.01f,

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -614,18 +614,18 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
     // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (packet.command) {
     case MAV_CMD_DO_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
 #if MOUNT == ENABLED
+        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 (float)packet.param3 * 0.01f,
                 0.0f,
                 0,
                 0);
-#endif
         }
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
+#endif
         break;
     default:
         break;
@@ -919,19 +919,19 @@ void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)
     // if the mount doesn't do pan control or mount is in follow-the-vehicle mode, then yaw the entire vehicle instead:
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
 #if MOUNT == ENABLED
+        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
             copter.flightmode->auto_yaw.set_fixed_yaw(
                 mavlink_msg_mount_control_get_input_c(&msg) * 0.01f,
                 0.0f,
                 0,
                 0);
-#endif
             break;
         }
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
+#endif
     }
     // GCS_MAVLINK::handle_command_mount handles all mount commands and checks if mount != nullptr
     GCS_MAVLINK::handle_mount_message(msg);

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -35,6 +35,24 @@ bool ModePlanckTracking::init(bool ignore_checks){
 
 void ModePlanckTracking::run() {
 
+    // check if gimbal steering needs to controlling the vehicle yaw
+    AP_Mount *mount = AP::mount();
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        float angle_deg = mount->get_follow_yaw_rate();
+        int8_t direction = 1;
+        bool relative_angle = true;
+        if (angle_deg < 0.0f) {
+            angle_deg = -angle_deg;
+            direction = -1;
+        }
+        // update auto_yaw private variable _fixed_yaw
+        copter.flightmode->auto_yaw.set_fixed_yaw(
+            angle_deg,
+            0, // use default angle change rate
+            direction,
+            relative_angle);
+    }
+
     //If there is new command data, send it to Guided
     if(copter.planck_interface.new_command_available()) {
         switch(copter.planck_interface.get_cmd_type()) {

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -54,12 +54,34 @@ void ModeStabilize::run()
         break;
     }
 
-    // call attitude controller
-    if ((auto_yaw.mode() != AUTO_YAW_FIXED)
-        || (target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+    AP_Mount *mount = AP::mount();
+    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
+        float angle_deg;
+        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
         // the total range of target_yaw_rate is about -10000 to 10000,
         // set the deadband to 200/10000 or 2% of the total range,
-        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
+        if ((target_yaw_rate > 200) || (target_yaw_rate < -200)) {
+            angle_deg = target_yaw_rate/1000.0f;
+        }
+        else {
+            angle_deg = mount->get_follow_yaw_rate();
+        }
+        int8_t direction = 1;
+        bool relative_angle = true;
+        if (angle_deg < 0.0f) {
+            angle_deg = -angle_deg;
+            direction = -1;
+        }
+        // update auto_yaw private variable _fixed_yaw
+        copter.flightmode->auto_yaw.set_fixed_yaw(
+            angle_deg,
+            0, // use default angle change rate
+            direction,
+            relative_angle);
+    }
+
+    // call attitude controller
+    if (auto_yaw.mode() != AUTO_YAW_FIXED) {
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
     }
     else {

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -54,32 +54,6 @@ void ModeStabilize::run()
         break;
     }
 
-    AP_Mount *mount = AP::mount();
-    if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        float angle_deg;
-        // allow the pilot to override the yaw_condition command if the commanded yaw is outside the deadband
-        // the total range of target_yaw_rate is about -10000 to 10000,
-        // set the deadband to 200/10000 or 2% of the total range,
-        if ((target_yaw_rate > 200) || (target_yaw_rate < -200)) {
-            angle_deg = target_yaw_rate/1000.0f;
-        }
-        else {
-            angle_deg = mount->get_follow_yaw_rate();
-        }
-        int8_t direction = 1;
-        bool relative_angle = true;
-        if (angle_deg < 0.0f) {
-            angle_deg = -angle_deg;
-            direction = -1;
-        }
-        // update auto_yaw private variable _fixed_yaw
-        copter.flightmode->auto_yaw.set_fixed_yaw(
-            angle_deg,
-            0, // use default angle change rate
-            direction,
-            relative_angle);
-    }
-
     // call attitude controller
     if (auto_yaw.mode() != AUTO_YAW_FIXED) {
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -427,6 +427,9 @@ void AP_Mount::init()
     // start with scaling disabled
     mount_scale_with_zoom = 1.0;
 
+    // responsiveness of the vehicle yaw when steered by the mount
+    vehicle_yaw_scale = 1.0;
+
     AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
 
     // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
@@ -567,13 +570,10 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
     _backends[instance]->set_angle_targets(roll, tilt, pan);
 }
 
-
-#define VEHICLE_YAW_SCALE 1.0f
 float AP_Mount::get_follow_yaw_rate()
 {
-    return VEHICLE_YAW_SCALE * yaw_encoder_readback;
+    return vehicle_yaw_scale * yaw_encoder_readback;
 }
-
 
 MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_long_t &packet)
 {

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -427,6 +427,11 @@ void AP_Mount::init()
     // start with scaling disabled
     mount_scale_with_zoom = 1.0;
 
+    AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
+
+    // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
+    AP_Mount::mount_yaw_follow_mode = gimbal_yaw_follows_vehicle;
+
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 
@@ -561,6 +566,14 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
     // send command to backend
     _backends[instance]->set_angle_targets(roll, tilt, pan);
 }
+
+
+#define VEHICLE_YAW_SCALE 1.0f
+float AP_Mount::get_follow_yaw_rate()
+{
+    return VEHICLE_YAW_SCALE * yaw_encoder_readback;
+}
+
 
 MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_long_t &packet)
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -134,6 +134,9 @@ public:
 
     float mount_scale_with_zoom;
 
+    // responsiveness of the vehicle yaw when steered by the mount
+    float vehicle_yaw_scale;
+
     enum MountYawFollowMode {
         gimbal_yaw_follows_vehicle = 0,
         vehicle_yaw_follows_gimbal = 1

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -134,7 +134,17 @@ public:
 
     float mount_scale_with_zoom;
 
+    enum MountYawFollowMode {
+        gimbal_yaw_follows_vehicle = 0,
+        vehicle_yaw_follows_gimbal = 1
+    };
+    MountYawFollowMode mount_yaw_follow_mode;
+
+    float get_follow_yaw_rate();
+
 protected:
+
+    float yaw_encoder_readback;
 
     static AP_Mount *_singleton;
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -326,4 +326,7 @@ private:
 
     // confirmed that last command was ok
     bool _last_command_confirmed : 1;
+
+    // Responsiveness of the gimbal to recenter with the vehicle
+    float gimbal_yaw_scale;
 };


### PR DESCRIPTION
- The mount leads when the yaw is steered using MAV_CMD_DO_MOUNT_CONTROL.
- The vehicle leads when the yaw is steered using MAV_CMD_CONDITION_YAW.
- This change improves camera object tracking dramatically.  The mount is able to yaw immediately to maintain track and the vehicle will yaw shortly afterwards to try to keep aligned with the mount.  Since the mount can yaw immediately and handle necessary higher frequency yaw adjustments, the whole object tracking experience is a lot smoother.