### PR TITLE
Planck copter 4.0.3 avem indago tracking restricted alt gain

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -430,14 +430,6 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
 
-    // @Param: PLANCK_NOM_KP_Z
-    // @DisplayName: Nominal KP alt
-    // @Description: Alt proportional gain used when not in Planck Land
-    // @Units: 1/s
-    // @Range: 0 100000
-    // @User: Advanced
-    GSCALAR(planck_nom_kp_z, "PLANCK_NOM_KP_Z",                 PLANCK_NOM_KP_ALT),
-
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain
     // @Description: Converts pilot roll and pitch into a desired rate of rotation in ACRO and SPORT mode.  Higher values mean faster rate of rotation.

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -423,13 +423,20 @@ const AP_Param::Info Copter::var_info[] = {
 
 
     // @Param: PLANCK_LAND_KP_Z
-    // @DisplayName: Planck Angle Timeout
-    // @Description: Time above PLANCK_ANGLE_MAX before triggering failsafe
-    // @Units: milliseconds
-    // @Range: 0 60000
+    // @DisplayName: Planck Land KP alt
+    // @Description: Alt proportional gain used in Planck Land
+    // @Units: 1/s
+    // @Range: 0 100000
     // @User: Advanced
     GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
 
+    // @Param: PLANCK_NOM_KP_Z
+    // @DisplayName: Nominal KP alt
+    // @Description: Alt proportional gain used when not in Planck Land
+    // @Units: 1/s
+    // @Range: 0 100000
+    // @User: Advanced
+    GSCALAR(planck_nom_kp_z, "PLANCK_NOM_KP_Z",                 PLANCK_NOM_KP_ALT),
 
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -421,6 +421,16 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(rc_speed, "RC_SPEED",              RC_FAST_SPEED),
 
+
+    // @Param: PLANCK_LAND_KP_Z
+    // @DisplayName: Planck Angle Timeout
+    // @Description: Time above PLANCK_ANGLE_MAX before triggering failsafe
+    // @Units: milliseconds
+    // @Range: 0 60000
+    // @User: Advanced
+    GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
+
+
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain
     // @Description: Converts pilot roll and pitch into a desired rate of rotation in ACRO and SPORT mode.  Higher values mean faster rate of rotation.

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -222,6 +222,9 @@ public:
         k_param_gcs3,
         k_param_gcs_pid_mask,    // 126
 
+        // 127: Planck Params
+        k_param_planck_land_kp_z, // 127
+
         //
         // 135 : reserved for Solo until features merged with master
         //
@@ -464,6 +467,9 @@ public:
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
     AP_Float                acro_rp_expo;
+
+    // planck Parameters
+    AP_Float                planck_land_kp_z;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -224,6 +224,7 @@ public:
 
         // 127: Planck Params
         k_param_planck_land_kp_z, // 127
+        k_param_planck_nom_kp_z, // 128
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -470,7 +471,7 @@ public:
 
     // planck Parameters
     AP_Float                planck_land_kp_z;
-
+    AP_Float                planck_nom_kp_z;
     // Note: keep initializers here in the same order as they are declared
     // above.
     Parameters()

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -224,7 +224,6 @@ public:
 
         // 127: Planck Params
         k_param_planck_land_kp_z, // 127
-        k_param_planck_nom_kp_z, // 128
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -471,7 +470,7 @@ public:
 
     // planck Parameters
     AP_Float                planck_land_kp_z;
-    AP_Float                planck_nom_kp_z;
+
     // Note: keep initializers here in the same order as they are declared
     // above.
     Parameters()

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -799,4 +799,5 @@
 // Planck Land kP alt
 #ifndef PLANCK_LAND_KP_ALT
  #define PLANCK_LAND_KP_ALT          .1     // Proportional alt gain used in planck land
+ #define PLANCK_NOM_KP_ALT           1
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -792,3 +792,11 @@
 #ifndef HAL_FRAME_TYPE_DEFAULT
 #define HAL_FRAME_TYPE_DEFAULT AP_Motors::MOTOR_FRAME_TYPE_X
 #endif
+
+//////////////////////////////////////////////////////////////////////////////
+// Planck Items
+//
+// Planck Land kP alt
+#ifndef PLANCK_LAND_KP_ALT
+ #define PLANCK_LAND_KP_ALT          .1     // Proportional alt gain used in planck land
+#endif

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -377,6 +377,10 @@ void Copter::exit_mode(Mode *&old_flightmode,
     }
 #endif
 
+    if (old_flightmode == &mode_planckland || old_flightmode == &mode_planckrtb) {
+        mode_planckland.exit();
+    }
+
 #if FRAME_CONFIG == HELI_FRAME
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_flightmode == &mode_acro) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1538,6 +1538,7 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; }
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
+    bool is_landing() const override { return _is_landing; }
 
 protected:
 
@@ -1561,8 +1562,11 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; }
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
+    void exit();
 
 protected:
+
+    float _kpz_nom = 1;
 
     const char *name() const override { return "PLANCKLAND"; }
     const char *name4() const override { return "PLND"; }

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -15,6 +15,7 @@ bool ModePlanckLand::init(bool ignore_checks){
         float land_velocity = abs((copter.g.land_speed > 0 ?
             copter.g.land_speed : copter.pos_control->get_max_speed_down()))/100.;
       copter.planck_interface.request_land(land_velocity);
+      copter.pos_control->get_pos_z_p().kP(g.planck_land_kp_z);
       return true;
     }
     return false;

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -6,6 +6,10 @@ bool ModePlanckLand::init(bool ignore_checks){
     if(copter.ap.land_complete)
       return false;
 
+    if(copter.pos_control->get_pos_z_p().kP().get() != _kpz_nom){
+      _kpz_nom = copter.pos_control->get_pos_z_p().kP().get();
+    }
+
     if(!copter.planck_interface.ready_for_land()) {
       return false;
     }
@@ -19,6 +23,12 @@ bool ModePlanckLand::init(bool ignore_checks){
       return true;
     }
     return false;
+}
+
+// perform cleanup required when leaving planck land mode
+void ModePlanckLand::exit()
+{
+    copter.pos_control->get_pos_z_p().kP(_kpz_nom);
 }
 
 void ModePlanckLand::run(){

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -4,7 +4,6 @@ bool ModePlanckTracking::init_without_RTB_request(bool ignore_checks) {
     //For initialization, if the GPS is bad but we have a tag detection,
     //just use GUIDED_NOGPS, as we don't want to require the use of GPS for
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
-
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
       ModeGuided::set_angle(Quaternion(),0,true,0);

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -4,6 +4,8 @@ bool ModePlanckTracking::init_without_RTB_request(bool ignore_checks) {
     //For initialization, if the GPS is bad but we have a tag detection,
     //just use GUIDED_NOGPS, as we don't want to require the use of GPS for
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
+
+    copter.pos_control->get_pos_z_p().kP(1);
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
       ModeGuided::set_angle(Quaternion(),0,true,0);

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -5,8 +5,6 @@ bool ModePlanckTracking::init_without_RTB_request(bool ignore_checks) {
     //just use GUIDED_NOGPS, as we don't want to require the use of GPS for
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
 
-    copter.pos_control->get_pos_z_p().kP(g.planck_nom_kp_z);
-
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
       ModeGuided::set_angle(Quaternion(),0,true,0);

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -5,7 +5,8 @@ bool ModePlanckTracking::init_without_RTB_request(bool ignore_checks) {
     //just use GUIDED_NOGPS, as we don't want to require the use of GPS for
     //GPS-denied operation.  Subsequent commands will be accel/attitude based.
 
-    copter.pos_control->get_pos_z_p().kP(1);
+    copter.pos_control->get_pos_z_p().kP(g.planck_nom_kp_z);
+
     if(!copter.position_ok() && copter.planck_interface.get_tag_tracking_state()) {
       //Set the angle to zero and a zero z rate; this prevents an initial drop
       ModeGuided::set_angle(Quaternion(),0,true,0);


### PR DESCRIPTION
This PR changes the pos_control altitude proportional gain depending on mode. When in planck land, it changes it to the parameter "PLANCK_LAND_KP_Z". When not in planck land, it uses the normal parameter "PSC_POSZ_P". 

addresses https://planckaero.atlassian.net/browse/AVEM-565