### PR TITLE
send muxed ascent rate lim in PLANCK_CMD_REQ_MOVE_TARGET

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -117,7 +117,7 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     if (!copter.flightmode->in_guided_mode()) {
         return;
     }
-    
+
     const GuidedMode guided_mode = copter.mode_guided.mode();
     Vector3f target_pos;
     Vector3f target_vel;
@@ -138,7 +138,7 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     mavlink_msg_position_target_local_ned_send(
         chan,
         AP_HAL::millis(), // time boot ms
-        MAV_FRAME_LOCAL_NED, 
+        MAV_FRAME_LOCAL_NED,
         type_mask,
         target_pos.x, // x in metres
         target_pos.y, // y in metres
@@ -879,7 +879,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             float north = packet.param1;
             float east = packet.param2;
             float up = packet.param3 + (copter.inertial_nav.get_position().z / 100.);
-            copter.planck_interface.request_move_target(Vector3f(north,east,up));
+            copter.planck_interface.request_move_target(Vector3f(north,east,up),false,copter.pos_control->get_max_speed_up(),copter.pos_control->get_max_speed_down());
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;
@@ -1102,7 +1102,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
                     copter.planck_interface.get_commbox_state()) &&
                     !copter.ap.land_complete)
                 {
-                    copter.planck_interface.request_alt_change(pos_vector.z / 100.);
+                    copter.planck_interface.request_alt_change(pos_vector.z / 100.,copter.pos_control->get_max_speed_up(),copter.pos_control->get_max_speed_down());
                 }
             }
             else
@@ -1301,7 +1301,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         copter.g2.toy_mode.handle_message(msg);
         break;
 #endif
-        
+
     default:
         handle_common_message(msg);
         break;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -117,7 +117,7 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     if (!copter.flightmode->in_guided_mode()) {
         return;
     }
-
+    
     const GuidedMode guided_mode = copter.mode_guided.mode();
     Vector3f target_pos;
     Vector3f target_vel;
@@ -138,7 +138,7 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     mavlink_msg_position_target_local_ned_send(
         chan,
         AP_HAL::millis(), // time boot ms
-        MAV_FRAME_LOCAL_NED,
+        MAV_FRAME_LOCAL_NED, 
         type_mask,
         target_pos.x, // x in metres
         target_pos.y, // y in metres
@@ -1301,7 +1301,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         copter.g2.toy_mode.handle_message(msg);
         break;
 #endif
-
+        
     default:
         handle_common_message(msg);
         break;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1647,8 +1647,10 @@ void ModeAuto::do_planck_wingman(const AP_Mission::Mission_Command& cmd)
       Vector3f(
         cmd.content.planck_wingman.x,
         cmd.content.planck_wingman.y,
-        (float)cmd.content.planck_wingman.z_cm/100.
-      )
+        (float)cmd.content.planck_wingman.z_cm/100.),
+      false,
+      copter.pos_control->get_max_speed_up(),
+      copter.pos_control->get_max_speed_down()
     );
     _planck_used = true;
 }

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -13,7 +13,7 @@ bool ModePlanckWingman::init(bool ignore_checks){
     if(copter.mode_plancktracking.init_without_RTB_request(ignore_checks)) {
 
       //And command a zero-rate, telling planck to maintain current relative position
-      copter.planck_interface.request_move_target(Vector3f(0,0,0),true);
+      copter.planck_interface.request_move_target(Vector3f(0,0,0),true,copter.pos_control->get_max_speed_up(),copter.pos_control->get_max_speed_down());
       return true;
     }
 
@@ -39,7 +39,7 @@ void ModePlanckWingman::run() {
 
       Vector3f rate_NED(N_rate, E_rate, z_rate); //NED
 
-      copter.planck_interface.request_move_target(rate_NED, true);
+      copter.planck_interface.request_move_target(rate_NED, true,copter.pos_control->get_max_speed_up(),copter.pos_control->get_max_speed_down());
 
       _next_req_send_t_ms = millis() + _send_rate_ms;
     }

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -135,10 +135,12 @@ void AC_Planck::request_takeoff(const float alt)
     0,0,0,0,0);
 }
 
-void AC_Planck::request_alt_change(const float alt)
+void AC_Planck::request_alt_change(const float alt, const float rate_up, const float rate_down)
 {
   //Only altitude is valid
   uint8_t valid = 0b00000100;
+  uint32_t max_rates = uint8_t(rate_up) << 8;
+  max_rates = max_rates | uint8_t(rate_down);
   mavlink_msg_planck_cmd_request_send(
     _chan,
     mavlink_system.sysid,
@@ -149,7 +151,7 @@ void AC_Planck::request_alt_change(const float alt)
     0,                //param3
     alt,              //param4
     0,                //param5
-    false);           //param6
+    *reinterpret_cast<float*>(&(max_rates)));           //param6
 }
 
 void AC_Planck::request_rtb(const float alt, const float rate_up, const float rate_down, const float rate_xy)
@@ -180,10 +182,12 @@ void AC_Planck::request_land(const float descent_rate)
 }
 
 //Move the current tracking target, either to an absolute offset or by a rate
-void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is_rate)
+void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up, const float rate_down)
 {
   //all directions and are valid
   uint8_t valid = 0b00000111;
+  uint32_t max_rates = uint8_t(rate_up) << 8;
+  max_rates = max_rates | uint8_t(rate_down);
   mavlink_msg_planck_cmd_request_send(
     _chan,
     mavlink_system.sysid,
@@ -194,7 +198,7 @@ void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is
     offset_cmd_NED.y, //param3
     offset_cmd_NED.z, //param4
     is_rate,          //param5
-    0);               //param6
+    *reinterpret_cast<float*>(&(max_rates)));               //param6
 
   //If the target has moved, the _was_at_location flag must go false until we
   //hear otherwise from planck

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -267,3 +267,16 @@ bool AC_Planck::get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, 
   _cmd.is_new = false;
   return true;
 }
+
+uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
+{
+  if (rate_down<0)
+    rate_down*=-1;
+
+  if (rate_up<0)
+    rate_up*=-1;
+
+  uint32_t muxed_rates = ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
+  muxed_rates = (muxed_rates & 0x7FFF7FFF) | 0x00008000;
+  return muxed_rates;
+};

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -276,6 +276,9 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
   if (rate_up<0)
     rate_up*=-1;
 
+  rate_up = std::fmin(rate_up,32767);
+  rate_down = std::fmin(rate_down,32767);
+
   uint32_t muxed_rates = ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
   muxed_rates = (muxed_rates & 0x7FFF7FFF) | 0x00008000;
   return muxed_rates;

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -135,12 +135,12 @@ void AC_Planck::request_takeoff(const float alt)
     0,0,0,0,0);
 }
 
-void AC_Planck::request_alt_change(const float alt, const float rate_up, const float rate_down)
+void AC_Planck::request_alt_change(const float alt, const float rate_up_cms, const float rate_down_cms)
 {
   //Only altitude is valid
   uint8_t valid = 0b00000100;
-  uint32_t max_rates = uint8_t(rate_up) << 8;
-  max_rates = max_rates | uint8_t(rate_down);
+  uint32_t muxed_rates = mux_rates(rate_up_cms,rate_down_cms);
+
   mavlink_msg_planck_cmd_request_send(
     _chan,
     mavlink_system.sysid,
@@ -151,7 +151,7 @@ void AC_Planck::request_alt_change(const float alt, const float rate_up, const f
     0,                //param3
     alt,              //param4
     0,                //param5
-    *reinterpret_cast<float*>(&(max_rates)));           //param6
+    *reinterpret_cast<float*>(&(muxed_rates)));           //param6
 }
 
 void AC_Planck::request_rtb(const float alt, const float rate_up, const float rate_down, const float rate_xy)
@@ -182,12 +182,12 @@ void AC_Planck::request_land(const float descent_rate)
 }
 
 //Move the current tracking target, either to an absolute offset or by a rate
-void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up, const float rate_down)
+void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up_cms, const float rate_down_cms)
 {
   //all directions and are valid
   uint8_t valid = 0b00000111;
-  uint32_t max_rates = uint8_t(rate_up) << 8;
-  max_rates = max_rates | uint8_t(rate_down);
+  uint32_t muxed_rates = mux_rates(rate_up_cms,rate_down_cms);
+
   mavlink_msg_planck_cmd_request_send(
     _chan,
     mavlink_system.sysid,
@@ -198,7 +198,7 @@ void AC_Planck::request_move_target(const Vector3f offset_cmd_NED, const bool is
     offset_cmd_NED.y, //param3
     offset_cmd_NED.z, //param4
     is_rate,          //param5
-    *reinterpret_cast<float*>(&(max_rates)));               //param6
+    *reinterpret_cast<float*>(&(muxed_rates)));               //param6
 
   //If the target has moved, the _was_at_location flag must go false until we
   //hear otherwise from planck

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -31,10 +31,10 @@ public:
 
   //Requesters to be sent to planck
   void request_takeoff(const float alt);
-  void request_alt_change(const float alt);
+  void request_alt_change(const float alt, const float rate_up, const float rate_down);
   void request_rtb(const float alt, const float rate_up, const float rate_down, const float rate_xy);
   void request_land(const float descent_rate);
-  void request_move_target(const Vector3f offset_cmd_NED, const bool is_rate = false);
+  void request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up, const float rate_down);
   void stop_commanding(void);
 
   //planck status getters

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -66,7 +66,7 @@ public:
   //Get a position, velocity, yaw command
   bool get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, bool &is_yaw_rate);
 
-  uint32_t mux_rates(const float rate_up, const float rate_down){return (uint16_t(rate_up) << 16) | uint16_t(rate_down);};
+  uint32_t mux_rates(const float rate_up, const float rate_down){return (uint32_t(rate_up) << 16) | uint32_t(rate_down);};
 
 private:
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -66,17 +66,7 @@ public:
   //Get a position, velocity, yaw command
   bool get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, bool &is_yaw_rate);
 
-  uint32_t mux_rates(float rate_up,  float rate_down){
-    if (rate_down<0)
-      rate_down*=-1;
-
-    if (rate_up<0)
-      rate_up*=-1;
-
-    uint32_t muxed_rates = ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
-    muxed_rates = (muxed_rates & 0x7FFF7FFF) | 0x00008000;
-    return muxed_rates;
-  };
+  uint32_t mux_rates(float rate_up,  float rate_down);
 
 private:
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -31,10 +31,10 @@ public:
 
   //Requesters to be sent to planck
   void request_takeoff(const float alt);
-  void request_alt_change(const float alt, const float rate_up, const float rate_down);
+  void request_alt_change(const float alt, const float rate_up_cms, const float rate_down_cms);
   void request_rtb(const float alt, const float rate_up, const float rate_down, const float rate_xy);
   void request_land(const float descent_rate);
-  void request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up, const float rate_down);
+  void request_move_target(const Vector3f offset_cmd_NED, const bool is_rate, const float rate_up_cms, const float rate_down_cms);
   void stop_commanding(void);
 
   //planck status getters
@@ -65,6 +65,8 @@ public:
 
   //Get a position, velocity, yaw command
   bool get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, bool &is_yaw_rate);
+
+  uint32_t mux_rates(const float rate_up, const float rate_down){return (uint16_t(rate_up) << 16) | uint16_t(rate_down);};
 
 private:
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -73,7 +73,9 @@ public:
     if (rate_up<0)
       rate_up*=-1;
 
-    return ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
+    uint32_t muxed_rates = ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
+    muxed_rates = (muxed_rates & 0x7FFF7FFF) | 0x00008000;
+    return muxed_rates;
   };
 
 private:

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -66,7 +66,15 @@ public:
   //Get a position, velocity, yaw command
   bool get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, bool &is_yaw_rate);
 
-  uint32_t mux_rates(const float rate_up, const float rate_down){return (uint32_t(rate_up) << 16) | uint32_t(rate_down);};
+  uint32_t mux_rates(float rate_up,  float rate_down){
+    if (rate_down<0)
+      rate_down*=-1;
+
+    if (rate_up<0)
+      rate_up*=-1;
+
+    return ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
+  };
 
 private:
 


### PR DESCRIPTION
This PR sends the WPNAV_SPEED_UP and WPNAV_SPEED_DOWN params to ACE in the PLANCK_CMD_REQ_MOVE_TARGET messages. It one slot, param 6, and muxes both of the params into a single param. WPNAV_SPEED_UP is represented by bits 9-16 while WPNAV_SPEED_DOWN is represented by bits 1-8 (with the least significant bit being number 1). 

Addresses https://planckaero.atlassian.net/browse/ACE-730