### PR TITLE
Handle yaw angle and rates from payload/tablet and prevent spinning when comms lost

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -622,11 +622,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
             && (copter.flightmode == &copter.mode_plancktracking);
 
         if(no_mount_pan_control && is_normal_tension_planck_tracking) {
-//            copter.flightmode->auto_yaw.set_fixed_yaw(
-//                (float)packet.param3 * 0.01f,
-//                0.0f,
-//                0,
-//                0);
             copter.flightmode->auto_yaw.set_rate((float)packet.param3);
             if(mount != nullptr)
             {
@@ -636,12 +631,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-//        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
-//                                  AP_HAL::micros64(),
-//                                  (float)packet.param3,
-//                                  (uint8_t)mount->mount_yaw_follow_mode,
-//                                  (uint8_t)mount->has_pan_control(),
-//                                  (uint8_t)copter.camera_mount.has_pan_control());
         break;
     }
 #endif

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -629,12 +629,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
-                           AP_HAL::micros64(),
-                           (float)packet.param3 * 0.01f,
-                           (uint8_t)mount->mount_yaw_follow_mode,
-                           (uint8_t)mount->has_pan_control(),
-                           (uint8_t)copter.camera_mount.has_pan_control());
         break;
 #endif
     default:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -623,7 +623,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
                 0);
             if(mount != nullptr)
             {
-            mount->set_last_mount_control_time_us(AP_HAL::micros64());
+                mount->set_last_mount_control_time_us(AP_HAL::micros64());
             }
         }
         else {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -615,9 +615,13 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
     switch (packet.command) {
 #if MOUNT == ENABLED
     case MAV_CMD_DO_MOUNT_CONTROL:
-        if((!copter.camera_mount.has_pan_control() || (mount == nullptr))
-           && (copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out())
-           && (copter.flightmode == &copter.mode_plancktracking)) {
+    {
+        bool has_mount_pan_control = (!copter.camera_mount.has_pan_control() || (mount == nullptr));
+        bool is_normal_tension_planck_tracking =
+            !(copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out())
+            && (copter.flightmode == &copter.mode_plancktracking);
+
+        if(has_mount_pan_control && is_normal_tension_planck_tracking) {
 //            copter.flightmode->auto_yaw.set_fixed_yaw(
 //                (float)packet.param3 * 0.01f,
 //                0.0f,
@@ -632,13 +636,14 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-//        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
-//                                  AP_HAL::micros64(),
-//                                  (float)packet.param3,
-//                                  (uint8_t)mount->mount_yaw_follow_mode,
-//                                  (uint8_t)mount->has_pan_control(),
-//                                  (uint8_t)copter.camera_mount.has_pan_control());
+        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
+                                  AP_HAL::micros64(),
+                                  (float)packet.param3,
+                                  (uint8_t)mount->mount_yaw_follow_mode,
+                                  (uint8_t)mount->has_pan_control(),
+                                  (uint8_t)copter.camera_mount.has_pan_control());
         break;
+    }
 #endif
     default:
         break;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -615,7 +615,9 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
     switch (packet.command) {
 #if MOUNT == ENABLED
     case MAV_CMD_DO_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
+        if((!copter.camera_mount.has_pan_control() || (mount == nullptr))
+           && (copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out())
+           && (copter.flightmode == &copter.mode_plancktracking)) {
 //            copter.flightmode->auto_yaw.set_fixed_yaw(
 //                (float)packet.param3 * 0.01f,
 //                0.0f,

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -623,7 +623,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
                 0);
             if(mount != nullptr)
             {
-            mount->set_last_payload_update_us(AP_HAL::micros64());
+            mount->set_last_mount_control_time_us(AP_HAL::micros64());
             }
         }
         else {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -630,12 +630,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
-                                  AP_HAL::micros64(),
-                                  (float)packet.param3,
-                                  (uint8_t)mount->mount_yaw_follow_mode,
-                                  (uint8_t)mount->has_pan_control(),
-                                  (uint8_t)copter.camera_mount.has_pan_control());
+//        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
+//                                  AP_HAL::micros64(),
+//                                  (float)packet.param3,
+//                                  (uint8_t)mount->mount_yaw_follow_mode,
+//                                  (uint8_t)mount->has_pan_control(),
+//                                  (uint8_t)copter.camera_mount.has_pan_control());
         break;
 #endif
     default:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -616,12 +616,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
 #if MOUNT == ENABLED
     case MAV_CMD_DO_MOUNT_CONTROL:
     {
-        bool has_mount_pan_control = (!copter.camera_mount.has_pan_control() || (mount == nullptr));
+        bool no_mount_pan_control = (!copter.camera_mount.has_pan_control() || (mount == nullptr));
         bool is_normal_tension_planck_tracking =
             !(copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out())
             && (copter.flightmode == &copter.mode_plancktracking);
 
-        if(has_mount_pan_control && is_normal_tension_planck_tracking) {
+        if(no_mount_pan_control && is_normal_tension_planck_tracking) {
 //            copter.flightmode->auto_yaw.set_fixed_yaw(
 //                (float)packet.param3 * 0.01f,
 //                0.0f,
@@ -636,12 +636,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
-        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
-                                  AP_HAL::micros64(),
-                                  (float)packet.param3,
-                                  (uint8_t)mount->mount_yaw_follow_mode,
-                                  (uint8_t)mount->has_pan_control(),
-                                  (uint8_t)copter.camera_mount.has_pan_control());
+//        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
+//                                  AP_HAL::micros64(),
+//                                  (float)packet.param3,
+//                                  (uint8_t)mount->mount_yaw_follow_mode,
+//                                  (uint8_t)mount->has_pan_control(),
+//                                  (uint8_t)copter.camera_mount.has_pan_control());
         break;
     }
 #endif

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -616,11 +616,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
 #if MOUNT == ENABLED
     case MAV_CMD_DO_MOUNT_CONTROL:
         if(!copter.camera_mount.has_pan_control() || (mount == nullptr)) {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                (float)packet.param3 * 0.01f,
-                0.0f,
-                0,
-                0);
+//            copter.flightmode->auto_yaw.set_fixed_yaw(
+//                (float)packet.param3 * 0.01f,
+//                0.0f,
+//                0,
+//                0);
+            copter.flightmode->auto_yaw.set_rate((float)packet.param3);
             if(mount != nullptr)
             {
                 mount->set_last_mount_control_time_us(AP_HAL::micros64());
@@ -629,6 +630,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
+        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
+                                  AP_HAL::micros64(),
+                                  (float)packet.param3,
+                                  (uint8_t)mount->mount_yaw_follow_mode,
+                                  (uint8_t)mount->has_pan_control(),
+                                  (uint8_t)copter.camera_mount.has_pan_control());
         break;
 #endif
     default:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -621,10 +621,20 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
                 0.0f,
                 0,
                 0);
+            if(mount != nullptr)
+            {
+            mount->set_last_payload_update_us(AP_HAL::micros64());
+            }
         }
         else {
             mount->mount_yaw_follow_mode = AP_Mount::vehicle_yaw_follows_gimbal;
         }
+        AP::logger().Write("HCMT", "TimeUS,P3,Myfm,MHPan,CHPan", "QfBBB",
+                           AP_HAL::micros64(),
+                           (float)packet.param3 * 0.01f,
+                           (uint8_t)mount->mount_yaw_follow_mode,
+                           (uint8_t)mount->has_pan_control(),
+                           (uint8_t)copter.camera_mount.has_pan_control());
         break;
 #endif
     default:

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -39,7 +39,12 @@ void ModePlanckTracking::run() {
     AP_Mount *mount = AP::mount();
     bool paylod_yaw_rate = false;
     float yaw_rate_for_logging_cds=18.4218;
-    if(mount != nullptr) {
+
+    //Check for tether high tension
+    bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
+    bool use_positive_throttle = high_tension;
+
+    if(mount != nullptr && !high_tension) {
       if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
 
         //only set new yaw command if payload data is recent (1/2 sec)
@@ -95,9 +100,6 @@ void ModePlanckTracking::run() {
 //                         (uint8_t)auto_yaw.mode());
     }
 
-    //Check for tether high tension
-    bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
-    bool use_positive_throttle = high_tension;
     if(high_tension) {
         //If we ever enter high tension, make sure ACE is landing
         if((copter.flightmode != &copter.mode_planckland) && (copter.flightmode != &copter.mode_planckrtb) && copter.planck_interface.ready_for_land()) {

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -38,11 +38,11 @@ void ModePlanckTracking::run() {
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
     bool paylod_yaw_rate = false;
-    if (mount != nullptr) {
+    if(mount != nullptr) {
       if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
 
         //only set new yaw command if payload data is recent (1/2 sec)
-        if (AP_HAL::micros64() - mount->get_last_payload_update_us()< 500000)
+        if (AP_HAL::micros64() - mount->get_last_payload_update_us() < 500000)
         {
           float angle_deg = mount->get_follow_yaw_rate() + degrees(copter.ahrs.get_yaw());
           int8_t direction = 1;
@@ -60,7 +60,7 @@ void ModePlanckTracking::run() {
       else if(!mount->has_pan_control() || mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
       {
         paylod_yaw_rate = true;
-        if (AP_HAL::micros64() - mount->get_last_payload_update_us() > 500000)
+        if(AP_HAL::micros64() - mount->get_last_mount_control_time_us() > 500000)
         {
           copter.flightmode->auto_yaw.set_fixed_yaw(
                 0.0f,

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -38,6 +38,7 @@ void ModePlanckTracking::run() {
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
     bool paylod_yaw_rate = false;
+    float yaw_rate_for_logging_cds=18.4218;
     if(mount != nullptr) {
       if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
 
@@ -68,7 +69,25 @@ void ModePlanckTracking::run() {
                 0,
                 0);
         }
+        else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
+        {
+          yaw_rate_for_logging_cds = copter.flightmode->auto_yaw.rate_cds();
+          copter.flightmode->auto_yaw.set_fixed_yaw(
+                copter.flightmode->auto_yaw.rate_cds(),
+                0.0f,
+                0,
+                0);
+
+        }
       }
+      AP::logger().Write("PTK1", "TimeUS,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QfffBBB",
+                               AP_HAL::micros64(),
+                         (float)yaw_rate_for_logging_cds,
+                         (float)auto_yaw.yaw(),
+                         (float)mount->get_follow_yaw_rate(),
+                         (uint8_t)mount->mount_yaw_follow_mode,
+                         (uint8_t)mount->has_pan_control(),
+                         (uint8_t)auto_yaw.mode());
     }
 
     //Check for tether high tension

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -38,7 +38,6 @@ void ModePlanckTracking::run() {
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
     bool paylod_yaw_rate = false;
-    bool set_rate_zero =false;
     if (mount != nullptr) {
       if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
 
@@ -68,19 +67,8 @@ void ModePlanckTracking::run() {
                 0.0f,
                 0,
                 0);
-          set_rate_zero = true;
         }
-
       }
-      AP::logger().Write("PTK1", "TimeUS,Ctus,Gfyr,Myfm,HPan,Lput,Szyr", "QQfBBQB",
-                         AP_HAL::micros64(),
-                         AP_HAL::micros64(),
-                         (float)mount->get_follow_yaw_rate(),
-                         (uint8_t)mount->mount_yaw_follow_mode,
-                         (uint8_t)mount->has_pan_control(),
-                         (uint64_t)mount->get_last_payload_update_us(),
-                         (uint8_t)set_rate_zero);
-
     }
 
     //Check for tether high tension

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -80,14 +80,19 @@ void ModePlanckTracking::run() {
 
         }
       }
-      AP::logger().Write("PTK1", "TimeUS,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QfffBBB",
-                               AP_HAL::micros64(),
-                         (float)yaw_rate_for_logging_cds,
-                         (float)auto_yaw.yaw(),
-                         (float)mount->get_follow_yaw_rate(),
-                         (uint8_t)mount->mount_yaw_follow_mode,
-                         (uint8_t)mount->has_pan_control(),
-                         (uint8_t)auto_yaw.mode());
+      static uint32_t next_yaw_report_t_ms = 0;
+      if(AP_HAL::millis() > next_yaw_report_t_ms) {
+          gcs().send_text(MAV_SEVERITY_INFO, "Yaw rate: %f %f %f %i %i %i",yaw_rate_for_logging_cds, auto_yaw.yaw(), mount->get_follow_yaw_rate(), mount->mount_yaw_follow_mode, mount->has_pan_control(), auto_yaw.mode());
+          next_yaw_report_t_ms = AP_HAL::millis() + 500;
+      }
+//      AP::logger().Write("PTK1", "TimeUS,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QfffBBB",
+//                               AP_HAL::micros64(),
+//                         (float)yaw_rate_for_logging_cds,
+//                         (float)auto_yaw.yaw(),
+//                         (float)mount->get_follow_yaw_rate(),
+//                         (uint8_t)mount->mount_yaw_follow_mode,
+//                         (uint8_t)mount->has_pan_control(),
+//                         (uint8_t)auto_yaw.mode());
     }
 
     //Check for tether high tension

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -38,13 +38,10 @@ void ModePlanckTracking::run() {
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
     if ((mount != nullptr) && (mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal)) {
-        float angle_deg = mount->get_follow_yaw_rate();
+        float angle_deg = mount->get_follow_yaw_rate() + degrees(copter.ahrs.get_yaw());
         int8_t direction = 1;
-        bool relative_angle = true;
-        if (angle_deg < 0.0f) {
-            angle_deg = -angle_deg;
-            direction = -1;
-        }
+        bool relative_angle = false;
+
         // update auto_yaw private variable _fixed_yaw
         copter.flightmode->auto_yaw.set_fixed_yaw(
             angle_deg,

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -38,7 +38,6 @@ void ModePlanckTracking::run() {
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
     bool paylod_yaw_rate = false;
-    float yaw_rate_for_logging_cds=18.4218;
 
     //Check for tether high tension
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
@@ -89,7 +88,6 @@ void ModePlanckTracking::run() {
           }
           else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
           {
-            yaw_rate_for_logging_cds = copter.flightmode->auto_yaw.rate_cds();
             copter.flightmode->auto_yaw.set_fixed_yaw(
                   copter.flightmode->auto_yaw.rate_cds(),
                   0.0f,
@@ -98,19 +96,6 @@ void ModePlanckTracking::run() {
 
           }
         }
-        static uint32_t next_yaw_report_t_ms = 0;
-        if(AP_HAL::millis() > next_yaw_report_t_ms) {
-          gcs().send_text(MAV_SEVERITY_INFO, "Yaw rate: %f %f %f %i %i %i",yaw_rate_for_logging_cds, auto_yaw.yaw(), mount->get_follow_yaw_rate(), mount->mount_yaw_follow_mode, mount->has_pan_control(), auto_yaw.mode());
-          next_yaw_report_t_ms = AP_HAL::millis() + 500;
-        }
-        //      AP::logger().Write("PTK1", "TimeUS,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QfffBBB",
-        //                               AP_HAL::micros64(),
-        //                         (float)yaw_rate_for_logging_cds,
-        //                         (float)auto_yaw.yaw(),
-        //                         (float)mount->get_follow_yaw_rate(),
-        //                         (uint8_t)mount->mount_yaw_follow_mode,
-        //                         (uint8_t)mount->has_pan_control(),
-        //                         (uint8_t)auto_yaw.mode());
       }
     }
 

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -509,8 +509,8 @@ void ModePosHold::run()
         }
         else if(!mount->has_pan_control() || mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle){
             //auto_yaw.yaw() is set when a CMD_DO_MOUNT_CONTROL message is received
-            target_yaw_rate = AP_HAL::micros64() - mount->get_last_mount_control_time_us() < 500000 ? auto_yaw.yaw() : 0;
-            auto_yaw.set_mode(AUTO_YAW_RATE);
+            target_yaw_rate = AP_HAL::micros64() - mount->get_last_mount_control_time_us() < 500000 ? auto_yaw.rate_cds() : 0;
+//            auto_yaw.set_mode(AUTO_YAW_RATE);
         }
         else if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
             //only set new yaw command if payload data is recent (1/2 sec)
@@ -528,6 +528,15 @@ void ModePosHold::run()
                     relative_angle);
             }
         }
+        AP::logger().Write("PHY1", "TimeUS,Tyr,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QffffBBB",
+                                 AP_HAL::micros64(),
+                                 (float)target_yaw_rate,
+                                 (float)auto_yaw.rate_cds(),
+                                 (float)auto_yaw.yaw(),
+                                 (float)mount->get_follow_yaw_rate(),
+                                 (uint8_t)mount->mount_yaw_follow_mode,
+                                 (uint8_t)mount->has_pan_control(),
+                                 (uint8_t)auto_yaw.mode());
     }
 
     // call attitude controller

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -528,15 +528,6 @@ void ModePosHold::run()
                     relative_angle);
             }
         }
-//        AP::logger().Write("PHY1", "TimeUS,Tyr,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QffffBBB",
-//                                 AP_HAL::micros64(),
-//                                 (float)target_yaw_rate,
-//                                 (float)auto_yaw.rate_cds(),
-//                                 (float)auto_yaw.yaw(),
-//                                 (float)mount->get_follow_yaw_rate(),
-//                                 (uint8_t)mount->mount_yaw_follow_mode,
-//                                 (uint8_t)mount->has_pan_control(),
-//                                 (uint8_t)auto_yaw.mode());
     }
 
     // call attitude controller

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -528,15 +528,15 @@ void ModePosHold::run()
                     relative_angle);
             }
         }
-        AP::logger().Write("PHY1", "TimeUS,Tyr,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QffffBBB",
-                                 AP_HAL::micros64(),
-                                 (float)target_yaw_rate,
-                                 (float)auto_yaw.rate_cds(),
-                                 (float)auto_yaw.yaw(),
-                                 (float)mount->get_follow_yaw_rate(),
-                                 (uint8_t)mount->mount_yaw_follow_mode,
-                                 (uint8_t)mount->has_pan_control(),
-                                 (uint8_t)auto_yaw.mode());
+//        AP::logger().Write("PHY1", "TimeUS,Tyr,Ayr,Ayy,Gfyr,Myfm,HPan,Aym", "QffffBBB",
+//                                 AP_HAL::micros64(),
+//                                 (float)target_yaw_rate,
+//                                 (float)auto_yaw.rate_cds(),
+//                                 (float)auto_yaw.yaw(),
+//                                 (float)mount->get_follow_yaw_rate(),
+//                                 (uint8_t)mount->mount_yaw_follow_mode,
+//                                 (uint8_t)mount->has_pan_control(),
+//                                 (uint8_t)auto_yaw.mode());
     }
 
     // call attitude controller

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -438,7 +438,8 @@ void AP_Mount::init()
 
     AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
     AP_Mount::yaw_encoder_readback_time_us = 0;
-    last_payload_update_us = 0;
+    last_mount_control_time_us = 0;
+
     // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
     AP_Mount::mount_yaw_follow_mode = gimbal_yaw_follows_vehicle;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -437,6 +437,7 @@ void AP_Mount::init()
     vehicle_yaw_scale = 1.0;
 
     AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
+    AP_Mount::yaw_encoder_readback_time_us = 0.0;
 
     // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
     AP_Mount::mount_yaw_follow_mode = gimbal_yaw_follows_vehicle;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -437,8 +437,8 @@ void AP_Mount::init()
     vehicle_yaw_scale = 1.0;
 
     AP_Mount::yaw_encoder_readback = 0.0; // readback yaw encoder position from the gimbal
-    AP_Mount::yaw_encoder_readback_time_us = 0.0;
-
+    AP_Mount::yaw_encoder_readback_time_us = 0;
+    last_payload_update_us = 0;
     // default is gimbal yaw follows the vehicle, use yaw encoder to move gimbal with the vehicle
     AP_Mount::mount_yaw_follow_mode = gimbal_yaw_follows_vehicle;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -147,15 +147,18 @@ public:
 
     float get_min_yaw_alt_cm() { return _min_yaw_alt_cm; };
 
-    uint64_t get_last_payload_update_us() { return last_payload_update_us; };
-    void set_last_payload_update_us(uint64_t time_us) {  last_payload_update_us=time_us; };
+    uint64_t get_last_payload_update_us() { return yaw_encoder_readback_time_us; };
 
+    uint64_t get_last_mount_control_time_us() { return last_mount_control_time_us; };
+
+    void set_last_mount_control_time_us(uint64_t time_us) {  last_mount_control_time_us=time_us; };
 
 protected:
 
     float yaw_encoder_readback;
+
     uint64_t yaw_encoder_readback_time_us;
-    uint64_t last_payload_update_us;
+    uint64_t last_mount_control_time_us;
 
     static AP_Mount *_singleton;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -147,9 +147,14 @@ public:
 
     float get_min_yaw_alt_cm() { return _min_yaw_alt_cm; };
 
+    float get_last_payload_update_us() { return yaw_encoder_readback_time_us; };
+    void set_last_payload_update_us(uint64_t time_us) {  yaw_encoder_readback_time_us=time_us; };
+
+
 protected:
 
     float yaw_encoder_readback;
+    uint64_t yaw_encoder_readback_time_us;
 
     static AP_Mount *_singleton;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -147,14 +147,15 @@ public:
 
     float get_min_yaw_alt_cm() { return _min_yaw_alt_cm; };
 
-    float get_last_payload_update_us() { return yaw_encoder_readback_time_us; };
-    void set_last_payload_update_us(uint64_t time_us) {  yaw_encoder_readback_time_us=time_us; };
+    uint64_t get_last_payload_update_us() { return last_payload_update_us; };
+    void set_last_payload_update_us(uint64_t time_us) {  last_payload_update_us=time_us; };
 
 
 protected:
 
     float yaw_encoder_readback;
     uint64_t yaw_encoder_readback_time_us;
+    uint64_t last_payload_update_us;
 
     static AP_Mount *_singleton;
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -236,8 +236,6 @@ void AP_Mount_Alexmos::send_command(uint8_t cmd, uint8_t* data, uint8_t size)
  */
 void AP_Mount_Alexmos::parse_body()
 {
-//    float log_encoder_readback = 0;
-//    bool mount_defined = false;
     switch (_command_id ) {
     case CMD_BOARD_INFO:
         _board_version = _buffer.version._board_version/ 10;
@@ -276,8 +274,6 @@ void AP_Mount_Alexmos::parse_body()
         if (mount != nullptr) {
             mount->yaw_encoder_readback = _current_angle.z;
             mount->yaw_encoder_readback_time_us = AP_HAL::micros64();
-            _log_encoder_readback = mount->yaw_encoder_readback;
-            _yaw_follow_mode=mount->mount_yaw_follow_mode;
         }
     }
     break;
@@ -294,29 +290,6 @@ void AP_Mount_Alexmos::parse_body()
         _last_command_confirmed = true;
         break;
 }
-
-
-
-    AP::logger().Write("AMT2", "TimeUS,GTA,BVrs,FVrs,BFTR,MMode,YMode,FMode,Pan", "QBBHHBBBB",
-                                            AP_HAL::micros64(),
-                                            (uint8_t)_gimbal_3axis,
-                                            (uint8_t)_buffer.version._board_version,
-                                            (uint16_t)_buffer.version._firmware_version,
-                                            (uint16_t)_buffer.version._board_features,
-                                            (uint8_t)_state._mode,
-                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
-                                            (uint8_t)_yaw_follow_mode,
-                                            (uint8_t)has_pan_control());
-
-    AP::logger().Write("AMNT", "TimeUS,CmdId,CAngZ,AngZ,EAngZ,SAngz,TAngZ,Enc", "QBffffff",
-                                            AP_HAL::micros64(),
-                                            (uint8_t)_command_id,
-                                            (float)_current_angle.z,
-                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw),
-                                            (float)degrees(_angle_ef_target_rad.z),
-                                            (float)_log_encoder_readback);
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,7 +1,6 @@
 ﻿#include "AP_Mount_Alexmos.h"
 #include <AP_GPS/AP_GPS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -15,9 +14,6 @@ void AP_Mount_Alexmos::init()
         get_boardinfo();
         read_params(0); //we request parameters for profile 0 and therfore get global and profile parameters
     }
-
-  _log_encoder_readback = 0.0f;
-  _yaw_follow_mode = 7;
 
     // Responsiveness of the gimbal to recenter with the vehicle
     gimbal_yaw_scale = 1.0/20.0f;
@@ -237,59 +233,59 @@ void AP_Mount_Alexmos::send_command(uint8_t cmd, uint8_t* data, uint8_t size)
 void AP_Mount_Alexmos::parse_body()
 {
     switch (_command_id ) {
-    case CMD_BOARD_INFO:
-        _board_version = _buffer.version._board_version/ 10;
-        _current_firmware_version = _buffer.version._firmware_version / 1000.0f ;
-        _firmware_beta_version = _buffer.version._firmware_version % 10 ;
-        _gimbal_3axis = (_buffer.version._board_features & 0x1);
-        _gimbal_bat_monitoring = (_buffer.version._board_features & 0x2);
+        case CMD_BOARD_INFO:
+            _board_version = _buffer.version._board_version/ 10;
+            _current_firmware_version = _buffer.version._firmware_version / 1000.0f ;
+            _firmware_beta_version = _buffer.version._firmware_version % 10 ;
+            _gimbal_3axis = (_buffer.version._board_features & 0x1);
+            _gimbal_bat_monitoring = (_buffer.version._board_features & 0x2);
+            break;
+
+        case CMD_GET_ANGLES:
+            _current_angle.x = VALUE_TO_DEGREE(_buffer.angles.angle_roll);
+            _current_angle.y = VALUE_TO_DEGREE(_buffer.angles.angle_pitch);
+            _current_angle.z = VALUE_TO_DEGREE(_buffer.angles.angle_yaw);
+            break;
+
+        case CMD_GET_ANGLES_EXT:
+        {
+            _current_angle.x = VALUE_TO_DEGREE(_buffer.angles_ext.angle_roll);
+            _current_angle.y = VALUE_TO_DEGREE(_buffer.angles_ext.angle_pitch);
+            _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw);
+            if (_state._roll_input_mode == AP_Mount::Input_Mode_Angle_Body_Frame) {
+                _current_angle.x = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_roll);
+            }
+            if (_state._pitch_input_mode == AP_Mount::Input_Mode_Angle_Body_Frame) {
+                _current_angle.y = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_pitch);
+            }
+            // The yaw angle reported by the IMU (angle_yaw) is very unreliable
+            // so use the body frame angle (stator_rotor_angle_yaw) unless
+            // the user specifically requests it (AP_Mount::Input_Mode_Angle_Absolute_Frame)
+            if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
+                _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw);
+            }
+
+            // make yaw encoder value visible outside the AP_Mount class
+            AP_Mount *mount = AP::mount();
+            if (mount != nullptr) {
+                mount->yaw_encoder_readback = _current_angle.z;
+                mount->yaw_encoder_readback_time_us = AP_HAL::micros64();
+            }
+        }
         break;
 
-    case CMD_GET_ANGLES:
-        _current_angle.x = VALUE_TO_DEGREE(_buffer.angles.angle_roll);
-        _current_angle.y = VALUE_TO_DEGREE(_buffer.angles.angle_pitch);
-        _current_angle.z = VALUE_TO_DEGREE(_buffer.angles.angle_yaw);
-        break;
+        case CMD_READ_PARAMS:
+            _param_read_once = true;
+            _current_parameters.params = _buffer.params;
+            break;
 
-    case CMD_GET_ANGLES_EXT:
-    {
-        _current_angle.x = VALUE_TO_DEGREE(_buffer.angles_ext.angle_roll);
-        _current_angle.y = VALUE_TO_DEGREE(_buffer.angles_ext.angle_pitch);
-        _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw);
-        if (_state._roll_input_mode == AP_Mount::Input_Mode_Angle_Body_Frame) {
-            _current_angle.x = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_roll);
-        }
-        if (_state._pitch_input_mode == AP_Mount::Input_Mode_Angle_Body_Frame) {
-            _current_angle.y = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_pitch);
-        }
-        // The yaw angle reported by the IMU (angle_yaw) is very unreliable
-        // so use the body frame angle (stator_rotor_angle_yaw) unless
-        // the user specifically requests it (AP_Mount::Input_Mode_Angle_Absolute_Frame)
-        if (_state._yaw_input_mode != AP_Mount::Input_Mode_Angle_Absolute_Frame) {
-            _current_angle.z = VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw);
-        }
+        case CMD_WRITE_PARAMS:
+            break;
 
-        // make yaw encoder value visible outside the AP_Mount class
-        AP_Mount *mount = AP::mount();
-        if (mount != nullptr) {
-            mount->yaw_encoder_readback = _current_angle.z;
-            mount->yaw_encoder_readback_time_us = AP_HAL::micros64();
-        }
+        default :
+            _last_command_confirmed = true;
+            break;
     }
-    break;
-
-    case CMD_READ_PARAMS:
-        _param_read_once = true;
-        _current_parameters.params = _buffer.params;
-        break;
-
-    case CMD_WRITE_PARAMS:
-        break;
-
-    default :
-        _last_command_confirmed = true;
-        break;
-}
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -293,33 +293,33 @@ void AP_Mount_Alexmos::parse_body()
             _last_command_confirmed = true;
             break;
     }
-    AP::logger().Write("AMT2", "TimeUS,GTA,BVrs,FVrs,BFTR,MMode,YMode,FMode,Pan", "QBBHHBBBB",
-                                            AP_HAL::micros64(),
-                                            (uint8_t)_gimbal_3axis,
-                                            (uint8_t)_buffer.version._board_version,
-                                            (uint16_t)_buffer.version._firmware_version,
-                                            (uint16_t)_buffer.version._board_features,
-                                            (uint8_t)_state._mode,
-                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
-                                            (uint8_t)_yaw_follow_mode,
-                                            (uint8_t)has_pan_control());
-
-    AP::logger().Write("AMNT", "TimeUS,CmdId,CAngZ,AngZ,EAngZ,SAngz,TAngZ,Enc", "QBffffff",
-                                            AP_HAL::micros64(),
-                                            AP_HAL::micros64(),
-                                            (uint8_t)_command_id,
-                                            (uint8_t)_command_id,
-                                            (float)_current_angle.z,
-                                            (float)_current_angle.z,
-                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
-                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw),
-                                            (float)degrees(_angle_ef_target_rad.z),
-                                            (float)degrees(_angle_ef_target_rad.z),
-                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
-                                            (float)_log_encoder_readback);
+//    AP::logger().Write("AMT2", "TimeUS,GTA,BVrs,FVrs,BFTR,MMode,YMode,FMode,Pan", "QBBHHBBBB",
+//                                            AP_HAL::micros64(),
+//                                            (uint8_t)_gimbal_3axis,
+//                                            (uint8_t)_buffer.version._board_version,
+//                                            (uint16_t)_buffer.version._firmware_version,
+//                                            (uint16_t)_buffer.version._board_features,
+//                                            (uint8_t)_state._mode,
+//                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
+//                                            (uint8_t)_yaw_follow_mode,
+//                                            (uint8_t)has_pan_control());
+//
+//    AP::logger().Write("AMNT", "TimeUS,CmdId,CAngZ,AngZ,EAngZ,SAngz,TAngZ,Enc", "QBffffff",
+//                                            AP_HAL::micros64(),
+//                                            AP_HAL::micros64(),
+//                                            (uint8_t)_command_id,
+//                                            (uint8_t)_command_id,
+//                                            (float)_current_angle.z,
+//                                            (float)_current_angle.z,
+//                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
+//                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
+//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
+//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
+//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw),
+//                                            (float)degrees(_angle_ef_target_rad.z),
+//                                            (float)degrees(_angle_ef_target_rad.z),
+//                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
+//                                            (float)_log_encoder_readback);
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -293,33 +293,6 @@ void AP_Mount_Alexmos::parse_body()
             _last_command_confirmed = true;
             break;
     }
-//    AP::logger().Write("AMT2", "TimeUS,GTA,BVrs,FVrs,BFTR,MMode,YMode,FMode,Pan", "QBBHHBBBB",
-//                                            AP_HAL::micros64(),
-//                                            (uint8_t)_gimbal_3axis,
-//                                            (uint8_t)_buffer.version._board_version,
-//                                            (uint16_t)_buffer.version._firmware_version,
-//                                            (uint16_t)_buffer.version._board_features,
-//                                            (uint8_t)_state._mode,
-//                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
-//                                            (uint8_t)_yaw_follow_mode,
-//                                            (uint8_t)has_pan_control());
-//
-//    AP::logger().Write("AMNT", "TimeUS,CmdId,CAngZ,AngZ,EAngZ,SAngz,TAngZ,Enc", "QBffffff",
-//                                            AP_HAL::micros64(),
-//                                            AP_HAL::micros64(),
-//                                            (uint8_t)_command_id,
-//                                            (uint8_t)_command_id,
-//                                            (float)_current_angle.z,
-//                                            (float)_current_angle.z,
-//                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
-//                                            (float)VALUE_TO_DEGREE(_buffer.angles.angle_yaw),
-//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
-//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.angle_yaw),
-//                                            (float)VALUE_TO_DEGREE(_buffer.angles_ext.stator_rotor_angle_yaw),
-//                                            (float)degrees(_angle_ef_target_rad.z),
-//                                            (float)degrees(_angle_ef_target_rad.z),
-//                                            (uint8_t)get_control_mode(_state._yaw_input_mode),
-//                                            (float)_log_encoder_readback);
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -89,6 +89,9 @@ public:
 
 private:
 
+    uint8_t _yaw_follow_mode;
+    float _log_encoder_readback;
+
     // get_angles -
     void get_angles();
 
@@ -329,4 +332,5 @@ private:
 
     // Responsiveness of the gimbal to recenter with the vehicle
     float gimbal_yaw_scale;
+
 };

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -89,6 +89,9 @@ public:
 
 private:
 
+    uint8_t _yaw_follow_mode;
+    float _log_encoder_readback;
+
     // get_angles -
     void get_angles();
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -89,9 +89,6 @@ public:
 
 private:
 
-    uint8_t _yaw_follow_mode;
-    float _log_encoder_readback;
-
     // get_angles -
     void get_angles();
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -329,5 +329,4 @@ private:
 
     // Responsiveness of the gimbal to recenter with the vehicle
     float gimbal_yaw_scale;
-
 };


### PR DESCRIPTION


In the current architecture, if copter.camera_mount.has_pan_control() returns false, then the yaw commands that are used are the ones set via mavlink  MAV_CMD_DO_MOUNT_CONTROL messages. However, these are yaw rates, where as mode_plancktracking expects yaw angle messages. This PR forces mode_plancktracking to interpret yaw commands coming from the tablet (via MAV_CMD_DO_MOUNT_CONTROL messages) as yaw rates, as forces mode_plancktracking to use these yaw rates only. when has_pan_control() returns false . Furthermore, a timeout is added for those commands, so if they stop, a zero yaw rate is used.

Additionally, a timeout is added to the payload yaw angle commands (which are different from the mavlink commands), and the yaw angle is frozen at the last received yaw command if payload yaw commands cease.  

Note that in the normal case, it is expected that copter.camera_mount.has_pan_control() returns true, so the yaw angle commands from the payload are used when that is the case. However, it has been observed that, for reasons unknown, copter.camera_mount.has_pan_control() returns false during some flights (this has not been seen to change mid-flight, only between power cycles), so it is necessary to be able to handle both cases, and this PR achieves that. Testing has shown the behavior will be similar in both cases, though a little "snappier" when expected that copter.camera_mount.has_pan_control() returns false. Previously, the user had extremely limited range of yaw control, and the aircraft point north whenever the user lifts their finger off the VCSI tablet.

The changes in this PR are as follows:

- Force mode_plancktracking to use an absolute yaw angle command, equal to the current aircraft heading + relative gimbal heading, as opposed to a relative heading angle command, when has_pan_control() is true (equivalently, when mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal).
- Force mode_plancktracking to use yaw rate commands when has_pan_control() is false (or, when mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
- Add a timeout for gimbal-aircraft heading offset messages, and freeze the heading command when the messages time out
- Add a timeout for MAV_CMD_DO_MOUNT_CONTROL messages (ie yaw rate commands from the tablet), and zero the yaw rate command when the messages time out

resolves https://planckaero.atlassian.net/browse/AVEM-590