### PR TITLE
AVEM hightension failsafes

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -58,6 +58,10 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
             check_failed(ARMING_CHECK_PLANCK_GPS, display_failure, "Planck Commbox GPS unhealthy");
             return false;
         }
+        if(copter.planck_interface.is_tether_timed_out()) {
+            check_failed(ARMING_CHECK_PLANCK_GPS, display_failure, "Planck Tether unhealthy");
+            return false;
+        }
     }
 
     return fence_checks(display_failure)

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -65,8 +65,6 @@ void Copter::update_throttle_hover()
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);
     }
-
-    copter.planck_interface.record_hover_throttle();
 #endif
 }
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -65,6 +65,8 @@ void Copter::update_throttle_hover()
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);
     }
+
+    copter.planck_interface.record_hover_throttle();
 #endif
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -822,7 +822,7 @@ private:
     void notify_flight_mode();
 
     // mode_land.cpp
-    void set_mode_land_with_pause(ModeReason reason);
+    void set_mode_land_with_pause(ModeReason reason, bool pause=true);
     bool landing_with_GPS();
 
     // motor_test.cpp

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -945,6 +945,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_PLANCK_STATUS:
     case MAVLINK_MSG_ID_PLANCK_CMD_MSG:
     case MAVLINK_MSG_ID_PLANCK_LANDING_TAG_ESTIMATE_NED:
+    case MAVLINK_MSG_ID_PLANCK_DECK_TETHER_STATUS:
         copter.planck_interface.handle_planck_mavlink_msg(chan, &msg, copter.ahrs);
         break;
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1449,3 +1449,8 @@ MAV_LANDED_STATE GCS_MAVLINK_Copter::landed_state() const
     }
     return MAV_LANDED_STATE_IN_AIR;
 }
+
+void* GCS_MAVLINK_Copter::get_planck_ptr()
+{
+    return (void*)(&(copter.planck_interface));
+}

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -64,4 +64,6 @@ private:
 
     void send_pid_tuning() override;
 
+    void* get_planck_ptr() override;
+
 };

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -430,12 +430,12 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
 
-        // @Param: PLANCK_EMERGENCY_THROTTLE
-    // @DisplayName: Planck Emergency Throttle Setting
-    // @Description: Fixed throttle setting when comms or pos ref is lost
+    // @Param: planck_high_tension_throttle_boost
+    // @DisplayName: Planck High Tension throttle boost
+    // @Description: Amount to increase the hover throttle during high tension events
     // @Range: 0 1
     // @User: Advanced
-    GSCALAR(planck_emergency_throttle, "PLANCK_EMT_THR",                 PLANCK_EMT_THR),
+    GSCALAR(planck_high_tension_throttle_boost, "PLANCK_HT_THR_B", PLANCK_HT_THR_B),
 
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -430,12 +430,12 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
 
-    // @Param: planck_high_tension_throttle_boost
-    // @DisplayName: Planck High Tension throttle boost
-    // @Description: Amount to increase the hover throttle during high tension events
-    // @Range: 0 1
+    // @Param: planck_high_tension_throttle
+    // @DisplayName: Planck High Tension throttle 
+    // @Description: fixed throttle value during high tension events
+    // @Range: 0.5 1
     // @User: Advanced
-    GSCALAR(planck_high_tension_throttle_boost, "PLANCK_HT_THR_B", PLANCK_HT_THR_B),
+    GSCALAR(planck_high_tension_throttle, "PLANCK_HT_THR", PLANCK_HT_THR),
 
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -430,6 +430,13 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_land_kp_z, "PLANCK_LAND_KP_Z",                 PLANCK_LAND_KP_ALT),
 
+        // @Param: PLANCK_EMERGENCY_THROTTLE
+    // @DisplayName: Planck Emergency Throttle Setting
+    // @Description: Fixed throttle setting when comms or pos ref is lost
+    // @Range: 0 1
+    // @User: Advanced
+    GSCALAR(planck_emergency_throttle, "PLANCK_EMT_THR",                 PLANCK_EMT_THR),
+
     // @Param: ACRO_RP_P
     // @DisplayName: Acro Roll and Pitch P gain
     // @Description: Converts pilot roll and pitch into a desired rate of rotation in ACRO and SPORT mode.  Higher values mean faster rate of rotation.

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -224,6 +224,7 @@ public:
 
         // 127: Planck Params
         k_param_planck_land_kp_z, // 127
+        k_param_planck_emergency_throttle, // 128
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -470,6 +471,7 @@ public:
 
     // planck Parameters
     AP_Float                planck_land_kp_z;
+    AP_Float                planck_emergency_throttle;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -224,7 +224,7 @@ public:
 
         // 127: Planck Params
         k_param_planck_land_kp_z, // 127
-        k_param_planck_high_tension_throttle_boost, // 128
+        k_param_planck_high_tension_throttle, // 128
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -471,7 +471,7 @@ public:
 
     // planck Parameters
     AP_Float                planck_land_kp_z;
-    AP_Float                planck_high_tension_throttle_boost;
+    AP_Float                planck_high_tension_throttle;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -224,7 +224,7 @@ public:
 
         // 127: Planck Params
         k_param_planck_land_kp_z, // 127
-        k_param_planck_emergency_throttle, // 128
+        k_param_planck_high_tension_throttle_boost, // 128
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -471,7 +471,7 @@ public:
 
     // planck Parameters
     AP_Float                planck_land_kp_z;
-    AP_Float                planck_emergency_throttle;
+    AP_Float                planck_high_tension_throttle_boost;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -804,5 +804,5 @@
 
 // Emergency Mode Throttle setting
 #ifndef PLANCK_HT_THR_B
- #define PLANCK_HT_THR_B              .15 //15%
+ #define PLANCK_HT_THR_B              .01 //1%
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -804,5 +804,5 @@
 
 // Emergency Mode Throttle setting
 #ifndef PLANCK_HT_THR
- #define PLANCK_HT_THR              0.6 //60%
+ #define PLANCK_HT_THR              0.65 //65%
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -803,6 +803,6 @@
 #endif
 
 // Emergency Mode Throttle setting
-#ifndef PLANCK_EMT_THR
- #define PLANCK_EMT_THR              .65
+#ifndef PLANCK_HT_THR_B
+ #define PLANCK_HT_THR_B              .15 //15%
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -803,6 +803,6 @@
 #endif
 
 // Emergency Mode Throttle setting
-#ifndef PLANCK_HT_THR_B
- #define PLANCK_HT_THR_B              .01 //1%
+#ifndef PLANCK_HT_THR
+ #define PLANCK_HT_THR              0.6 //60%
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -801,3 +801,8 @@
  #define PLANCK_LAND_KP_ALT          .1     // Proportional alt gain used in planck land
  #define PLANCK_NOM_KP_ALT           1
 #endif
+
+// Emergency Mode Throttle setting
+#ifndef PLANCK_EMT_THR
+ #define PLANCK_EMT_THR              .65
+#endif

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -834,7 +834,7 @@ private:
     void takeoff_run();
     void pos_control_run();
     void vel_control_run(bool force_positive_throttle = false);
-    void posvel_control_run();
+    void posvel_control_run(bool force_positive_throttle = false);
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -833,7 +833,7 @@ private:
     void posvel_control_start();
     void takeoff_run();
     void pos_control_run();
-    void vel_control_run();
+    void vel_control_run(bool force_positive_throttle = false);
     void posvel_control_run();
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -815,7 +815,7 @@ public:
     GuidedMode mode() const { return guided_mode; }
 
     void angle_control_start();
-    void angle_control_run(bool high_jerk_z = false, bool force_positive_throttle = false);
+    void angle_control_run(bool high_jerk_z = false);
 
 protected:
 
@@ -833,13 +833,15 @@ private:
     void posvel_control_start();
     void takeoff_run();
     void pos_control_run();
-    void vel_control_run(bool force_positive_throttle = false);
-    void posvel_control_run(bool force_positive_throttle = false);
+    void vel_control_run();
+    void posvel_control_run();
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 
     // controls which controller is run (pos or vel):
     GuidedMode guided_mode = Guided_TakeOff;
+
+    bool _force_positive_throttle = false;
 
 };
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -786,8 +786,8 @@ public:
     using Mode::Mode;
 
     bool init(bool ignore_checks) override;
-    void run() override { this->run(false); };
-    void run(bool high_jerk_z);
+    void run() override { this->run(false, false); };
+    void run(bool high_jerk_z, bool force_positive_throttle);
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
@@ -815,7 +815,7 @@ public:
     GuidedMode mode() const { return guided_mode; }
 
     void angle_control_start();
-    void angle_control_run(bool high_jerk_z = false);
+    void angle_control_run(bool high_jerk_z = false, bool force_positive_throttle = false);
 
 protected:
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -650,6 +650,7 @@ void ModeGuided::angle_control_run(bool high_jerk_z)
     // call position controller
     if(_force_positive_throttle) {
         attitude_control->set_throttle_out(g.planck_emergency_throttle, true, g.throttle_filt);
+        pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
         pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false, high_jerk_z);
         pos_control->update_z_controller();

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -493,7 +493,7 @@ void ModeGuided::vel_control_run()
 
     if(_force_positive_throttle) {
       pos_control->update_vel_controller_xy();
-      attitude_control->set_throttle_out(g.planck_emergency_throttle, true, g.throttle_filt);
+      attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
       pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
       // call velocity controller which includes z axis controller
@@ -566,7 +566,7 @@ void ModeGuided::posvel_control_run()
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(g.planck_emergency_throttle, true, g.throttle_filt);
+        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
         pos_control->update_z_controller();
@@ -649,7 +649,7 @@ void ModeGuided::angle_control_run(bool high_jerk_z)
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(g.planck_emergency_throttle, true, g.throttle_filt);
+        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
         pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false, high_jerk_z);

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -335,7 +335,7 @@ void ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms, bool use_y
 void ModeGuided::run(bool high_jerk_z, bool force_positive_throttle)
 {
     if(!_force_positive_throttle && force_positive_throttle) {
-        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        float throttle = constrain_float(g.planck_high_tension_throttle, 0.5, 1.0);
         gcs().send_text(MAV_SEVERITY_INFO,"POSTHR: %f\n", throttle);
     }
     _force_positive_throttle = force_positive_throttle;
@@ -497,7 +497,7 @@ void ModeGuided::vel_control_run()
 
     if(_force_positive_throttle) {
       pos_control->update_vel_controller_xy();
-      float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+      float throttle = constrain_float(g.planck_high_tension_throttle, 0.5, 1.0);
       attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
       pos_control->relax_alt_hold_controllers(throttle);
     } else {
@@ -571,7 +571,7 @@ void ModeGuided::posvel_control_run()
 
     // call position controller
     if(_force_positive_throttle) {
-        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        float throttle = constrain_float(g.planck_high_tension_throttle, 0.5, 1.0);
         attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(throttle);
     } else {
@@ -655,7 +655,7 @@ void ModeGuided::angle_control_run(bool high_jerk_z)
 
     // call position controller
     if(_force_positive_throttle) {
-        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        float throttle = constrain_float(g.planck_high_tension_throttle, 0.5, 1.0);
         attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(throttle);
     } else {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -334,6 +334,10 @@ void ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms, bool use_y
 // should be called at 100hz or more
 void ModeGuided::run(bool high_jerk_z, bool force_positive_throttle)
 {
+    if(!_force_positive_throttle && force_positive_throttle) {
+        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        gcs().send_text(MAV_SEVERITY_INFO,"POSTHR: %f\n", throttle);
+    }
     _force_positive_throttle = force_positive_throttle;
 
     // call the correct auto controller
@@ -493,8 +497,9 @@ void ModeGuided::vel_control_run()
 
     if(_force_positive_throttle) {
       pos_control->update_vel_controller_xy();
-      attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
-      pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
+      float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+      attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
+      pos_control->relax_alt_hold_controllers(throttle);
     } else {
       // call velocity controller which includes z axis controller
       pos_control->update_vel_controller_xyz();
@@ -566,8 +571,9 @@ void ModeGuided::posvel_control_run()
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
-        pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
+        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
+        pos_control->relax_alt_hold_controllers(throttle);
     } else {
         pos_control->update_z_controller();
     }
@@ -649,8 +655,9 @@ void ModeGuided::angle_control_run(bool high_jerk_z)
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
-        pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
+        float throttle = copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost);
+        attitude_control->set_throttle_out(throttle, true, g.throttle_filt);
+        pos_control->relax_alt_hold_controllers(throttle);
     } else {
         pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false, high_jerk_z);
         pos_control->update_z_controller();

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -493,7 +493,7 @@ void ModeGuided::vel_control_run()
 
     if(_force_positive_throttle) {
       pos_control->update_vel_controller_xy();
-      attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
+      attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
       pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
       // call velocity controller which includes z axis controller
@@ -566,7 +566,7 @@ void ModeGuided::posvel_control_run()
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
+        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
         pos_control->update_z_controller();
@@ -649,7 +649,7 @@ void ModeGuided::angle_control_run(bool high_jerk_z)
 
     // call position controller
     if(_force_positive_throttle) {
-        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_emergency_throttle), true, g.throttle_filt);
+        attitude_control->set_throttle_out(copter.planck_interface.calculate_pos_throttle(copter.g.planck_high_tension_throttle_boost), true, g.throttle_filt);
         pos_control->relax_alt_hold_controllers(attitude_control->get_throttle_in());
     } else {
         pos_control->set_alt_target_from_climb_rate_ff(climb_rate_cms, G_Dt, false, high_jerk_z);

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -145,10 +145,10 @@ void ModeLand::do_not_use_GPS()
 
 // set_mode_land_with_pause - sets mode to LAND and triggers 4 second delay before descent starts
 //  this is always called from a failsafe so we trigger notification to pilot
-void Copter::set_mode_land_with_pause(ModeReason reason)
+void Copter::set_mode_land_with_pause(ModeReason reason, bool pause)
 {
     set_mode(Mode::Number::LAND, reason);
-    land_pause = true;
+    land_pause = pause;
 
     // alert pilot to mode change
     AP_Notify::events.failsafe_mode_change = 1;

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -6,7 +6,7 @@ bool ModePlanckLand::init(bool ignore_checks){
     if(copter.ap.land_complete)
       return false;
 
-    if(copter.pos_control->get_pos_z_p().kP().get() != _kpz_nom){
+    if(!is_equal(copter.pos_control->get_pos_z_p().kP().get(),_kpz_nom)){
       _kpz_nom = copter.pos_control->get_pos_z_p().kP().get();
     }
 

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -80,9 +80,6 @@ void ModePlanckTracking::run() {
                 return;
             }
         }
-    } else {
-        //Record the hover throttle up until a high tension event
-        copter.planck_interface.record_hover_throttle();
     }
 
     //If there is new command data, send it to Guided

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -76,7 +76,7 @@ void ModePlanckTracking::run() {
             }
         } else { //High tension has timed out
             //If high tension has failed, attempt to use a planck land or regular land
-            copter.set_mode_land_with_pause(ModeReason::GCS_FAILSAFE);
+            copter.set_mode_land_with_pause(ModeReason::GCS_FAILSAFE, false);
             copter.mode_land.run();
             return;
         }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -70,6 +70,11 @@ void ModePlanckTracking::run() {
             if(!copter.planck_interface.get_tag_tracking_state()) {
                 if(copter.position_ok()) {
                   copter.planck_interface.override_with_zero_vel_cmd();
+
+                  //Force the position controller to use the current position
+                  const Vector3f& curr_pos = inertial_nav.get_position();
+                  // set target position to current position
+                  pos_control->set_xy_target(curr_pos.x, curr_pos.y);
                 } else {
                   copter.planck_interface.override_with_zero_att_cmd();
                 }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -222,7 +222,8 @@ void ModePlanckTracking::run() {
     }
 
     //Run the guided mode controller
-    ModeGuided::run(true); //use high-jerk
+    bool use_positive_throttle = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
+    ModeGuided::run(true, use_positive_throttle); //use high-jerk, positive throttle if necessary
 }
 
 bool ModePlanckTracking::do_user_takeoff_start(float final_alt_above_home)

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -55,16 +55,29 @@ void ModePlanckTracking::run() {
 
     //Check for tether high tension
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
+    bool use_positive_throttle = high_tension;
     if(high_tension) {
-        //While in high tension:
-        // - If actively tracking the tag, continue to do so, but use pos throttle
-        // - If not tracking the tag, but tracking the ground GPS, continue to do so, but use pos throttle
-        // - If not tracking tag or ground GPS, use zero velocity command (if gps available, zero attitude if not) with pos throttle
-        if(!copter.planck_interface.get_tag_tracking_state() && !copter.planck_interface.get_commbox_state()) {
-            if(copter.position_ok()) {
-              copter.planck_interface.override_with_zero_vel_cmd();
+        if(!copter.planck_interface.check_if_high_tension_failed(copter.current_loc.alt)) { //High tension hasn't failed
+            //While in high tension:
+            // - If actively tracking the tag, continue to do so, but use pos throttle
+            // - If not tracking the tag, but tracking the ground GPS, continue to do so, but use pos throttle
+            // - If not tracking tag or ground GPS, use zero velocity command (if gps available, zero attitude if not) with pos throttle
+            if(!copter.planck_interface.get_tag_tracking_state() && !copter.planck_interface.get_commbox_state()) {
+                if(copter.position_ok()) {
+                  copter.planck_interface.override_with_zero_vel_cmd();
+                } else {
+                  copter.planck_interface.override_with_zero_att_cmd();
+                }
+            }
+        } else { //High tension has failed
+            //If high tension has failed, attempt to use a planck land or regular land
+            if(copter.planck_interface.ready_for_land()) {
+                copter.set_mode_planck_RTB_or_planck_land(ModeReason::GCS_FAILSAFE);
+                use_positive_throttle = false; //Use normal altitude control
             } else {
-              copter.planck_interface.override_with_zero_att_cmd();
+                copter.set_mode_land_with_pause(ModeReason::GCS_FAILSAFE);
+                copter.mode_land.run();
+                return;
             }
         }
     }
@@ -238,7 +251,7 @@ void ModePlanckTracking::run() {
     }
 
     //Run the guided mode controller
-    ModeGuided::run(true, high_tension); //use high-jerk, positive throttle if necessary
+    ModeGuided::run(true, use_positive_throttle); //use high-jerk, positive throttle if necessary
 }
 
 bool ModePlanckTracking::do_user_takeoff_start(float final_alt_above_home)

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -57,6 +57,11 @@ void ModePlanckTracking::run() {
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
     bool use_positive_throttle = high_tension;
     if(high_tension) {
+        //If we ever enter high tension, make sure ACE is landing
+        if((copter.flightmode != &copter.mode_planckland) && (copter.flightmode != &copter.mode_planckrtb)) {
+            copter.set_mode_planck_RTB_or_planck_land(ModeReason::GCS_FAILSAFE);
+        }
+
         if(!copter.planck_interface.check_for_high_tension_timeout()) { //High tension hasn't failed
             //While in high tension:
             // - If actively tracking the tag, continue to do so, but use pos throttle

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -58,7 +58,7 @@ void ModePlanckTracking::run() {
     bool use_positive_throttle = high_tension;
     if(high_tension) {
         //If we ever enter high tension, make sure ACE is landing
-        if((copter.flightmode != &copter.mode_planckland) && (copter.flightmode != &copter.mode_planckrtb)) {
+        if((copter.flightmode != &copter.mode_planckland) && (copter.flightmode != &copter.mode_planckrtb) && copter.planck_interface.ready_for_land()) {
             copter.set_mode_planck_RTB_or_planck_land(ModeReason::GCS_FAILSAFE);
         }
 

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -80,6 +80,9 @@ void ModePlanckTracking::run() {
                 return;
             }
         }
+    } else {
+        //Record the hover throttle up until a high tension event
+        copter.planck_interface.record_hover_throttle();
     }
 
     //If there is new command data, send it to Guided

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -337,6 +337,11 @@ bool AC_Planck::get_posvel_cmd(Location &loc, Vector3f &vel_cms, float &yaw_cd, 
 }
 
 bool AC_Planck::check_for_high_tension_timeout() {
+  //No failure if not flying
+  if(AP_Motors::get_singleton()->get_spool_state() == AP_Motors::SpoolState::SHUT_DOWN) {
+    return false;
+  }
+
   //No comms from the tether
   bool tether_comms_failed = is_tether_timed_out();
 

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -368,7 +368,8 @@ bool AC_Planck::check_for_high_tension_timeout() {
     timeout_s = _tether_status.high_tension_alt_cm / reel_rate_cms;
   }
 
-  //Account for the 10s spent in "locked" mode, but only in a comms or position loss state
+  //Account for the 10s spent in "locked" mode, but only in a comms or position loss state.
+  //Note: we only check the commbox state, as thats what the tether logic uses
   bool pos_reference_good = get_commbox_state() || get_tag_tracking_state();
   if(!pos_reference_good || tether_comms_failed) {
     timeout_s += 10.;

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -412,7 +412,7 @@ void AC_Planck::record_hover_throttle() {
 }
 
 float AC_Planck::calculate_pos_throttle(const float boost_pct) {
-  return constrain_float(_hover_throttle_before_high_tension + boost_pct, _hover_throttle_before_high_tension, 1.);
+  return constrain_float(_hover_throttle_before_high_tension + boost_pct, 0.5, 1.);
 }
 
 bool AC_Planck::is_tether_timed_out() {

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -385,7 +385,7 @@ bool AC_Planck::check_for_high_tension_timeout() {
   }
 
   if(timed_out && !_tether_status.sent_failed_message) {
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Tether tensioner failure. DT: %lu", timeout_time_ms);
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Tether high-tension timeout");
     _tether_status.sent_failed_message = true;
   }
   return timed_out;

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -406,3 +406,14 @@ void AC_Planck::record_hover_throttle() {
 float AC_Planck::calculate_pos_throttle(const float boost_pct) {
   return constrain_float(_hover_throttle_before_high_tension + boost_pct, _hover_throttle_before_high_tension, 1.);
 }
+
+bool AC_Planck::is_tether_timed_out() {
+  bool timed_out = ((AP_HAL::millis() - _tether_status.timestamp_ms) > 5000);
+  if(timed_out && !_tether_status.comms_timed_out) {
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Tether comms timed out");
+  } else if (!timed_out && _tether_status.comms_timed_out) {
+    gcs().send_text(MAV_SEVERITY_INFO, "Tether comms restored");
+  }
+  _tether_status.comms_timed_out = timed_out;
+  return timed_out;
+}

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -160,7 +160,7 @@ void AC_Planck::handle_planck_mavlink_msg(const mavlink_channel_t &chan, const m
         if(_status.tracking_tag) {
           _tether_status.high_tension_tag_alt_cm = _tag_est.tag_pos_cm.z;
         } else {
-          _tether_status.high_tension_tag_alt_cm = 0;
+          _tether_status.high_tension_tag_alt_cm = 0.0f;
         }
 
         Location current_loc;
@@ -172,8 +172,8 @@ void AC_Planck::handle_planck_mavlink_msg(const mavlink_channel_t &chan, const m
       //If transitioning out of high tension, reset recorded values
       if(!high_tension && _tether_status.high_tension) {
         _tether_status.high_tension_timestamp_ms = 0;
-        _tether_status.high_tension_tag_alt_cm = 0;
-        _tether_status.high_tension_alt_cm = 0;
+        _tether_status.high_tension_tag_alt_cm = 0.0f;
+        _tether_status.high_tension_alt_cm = 0.0f;
         gcs().send_text(MAV_SEVERITY_INFO, "Tether Tension Mode Change: Nominal");
       }
 
@@ -367,8 +367,11 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
   bool alt_increased = ((float)alt_cm >= alt_threshold);
 
   //Check if the tag altitude stayed the same or increased. Add a 2m buffer
-  float tag_alt_threshold = _tether_status.high_tension_tag_alt_cm - 200.;
-  bool tag_alt_increased = _status.tracking_tag ? (_tag_est.tag_pos_cm.z >= tag_alt_threshold) : false;
+  bool tag_alt_increased = false;
+  if(!is_equal(_tether_status.high_tension_tag_alt_cm,0.0f)) {
+      float tag_alt_threshold = _tether_status.high_tension_tag_alt_cm - 200.;
+      tag_alt_increased = _status.tracking_tag ? (_tag_est.tag_pos_cm.z >= tag_alt_threshold) : false;
+  }
 
   //At this point, its been 15s since we should have been pulled down.
   //If the altitude hasn't decreased, the tensioner likely failed

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -405,16 +405,6 @@ void AC_Planck::override_with_zero_att_cmd() {
   _cmd.is_new = true;
 }
 
-void AC_Planck::record_hover_throttle() {
-  if(!is_tether_high_tension() && !is_tether_timed_out()) {
-    _hover_throttle_before_high_tension = AP_Motors::get_singleton()->get_throttle_hover();
-  }
-}
-
-float AC_Planck::calculate_pos_throttle(const float boost_pct) {
-  return constrain_float(_hover_throttle_before_high_tension + boost_pct, 0.5, 1.);
-}
-
 bool AC_Planck::is_tether_timed_out() {
   bool timed_out = ((AP_HAL::millis() - _tether_status.timestamp_ms) > 5000);
   if(timed_out && !_tether_status.comms_timed_out) {

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -350,7 +350,7 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
   //Check for a timeout. Has it been 15s since the tether indicated high tension,
   //or 15s since we last heard the tether comms timed out
   bool timeout = false;
-  if(!tether_comms_failed) {
+  if(_tether_status.high_tension) {
     timeout = (AP_HAL::millis() - _tether_status.high_tension_timestamp_ms) > 15000;
   } else { //Tether comms have failed
     timeout = (AP_HAL::millis() - _tether_status.timestamp_ms) > 20000; //15s + 5s timeout

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -342,6 +342,7 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
 
   //Hasn't failed if not triggered
   if(!high_tension_triggered) {
+    _tether_status.sent_failed_message = false;
     return false;
   }
 
@@ -356,6 +357,7 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
 
   //If no timeout, it hasn't failed yet
   if(!timeout) {
+    _tether_status.sent_failed_message = false;
     return false;
   }
 
@@ -369,5 +371,10 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
 
   //At this point, its been 15s since we should have been pulled down.
   //If the altitude hasn't decreased, the tensioner likely failed
-  return (alt_increased || tag_alt_increased);
+  bool failed = (alt_increased || tag_alt_increased);
+  if(failed && !_tether_status.sent_failed_message) {
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Tether tensioner failure detection");
+    _tether_status.sent_failed_message = true;
+  }
+  return failed;
 }

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -366,18 +366,17 @@ bool AC_Planck::check_for_high_tension_timeout() {
 
   //The amount of time to wait for high tension to timeout is a function of
   //initial altitude when the high tension event ocurred. Use tag altitude if available
-  float timeout_ms = 0;
+  float timeout_s = 0;
   const float reel_rate_cms = 60.96; //~2ft/s
   if(!is_equal(_tether_status.high_tension_tag_alt_cm,0.0f)) {
-    timeout_ms = 100. * (_tether_status.high_tension_tag_alt_cm / reel_rate_cms);
+    timeout_s = _tether_status.high_tension_tag_alt_cm / reel_rate_cms;
   } else {
-    timeout_ms = 100. * (_tether_status.high_tension_alt_cm / reel_rate_cms);
+    timeout_s = _tether_status.high_tension_alt_cm / reel_rate_cms;
   }
   //Add a 5s buffer, limit
-  timeout_ms += 500.;
-  timeout_ms = constrain_float(timeout_ms, 500., 12000.); //5s to 2 minutes
+  timeout_s = constrain_float((timeout_s + 5.), 5., 120.); //5s to 2 minutes
 
-  uint32_t timeout_time_ms = _tether_status.high_tension_timestamp_ms + (uint32_t)timeout_ms;
+  uint32_t timeout_time_ms = _tether_status.high_tension_timestamp_ms + (uint32_t)(timeout_s * 1000.);
   bool timed_out = AP_HAL::millis() > timeout_time_ms;
 
   if(timed_out && !_tether_status.sent_failed_message) {

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -378,3 +378,17 @@ bool AC_Planck::check_if_high_tension_failed(const int32_t alt_cm) {
   }
   return failed;
 }
+
+void AC_Planck::override_with_zero_vel_cmd() {
+  _cmd.zero();
+  _cmd.type = VELOCITY;
+  _cmd.timestamp_ms = AP_HAL::millis();
+  _cmd.is_new = true;
+}
+
+void AC_Planck::override_with_zero_att_cmd() {
+  _cmd.zero();
+  _cmd.type = ATTITUDE;
+  _cmd.timestamp_ms = AP_HAL::millis();
+  _cmd.is_new = true;
+}

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -2,6 +2,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "../ArduCopter/defines.h"
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Motors/AP_Motors.h>
 
 void AC_Planck::handle_planck_mavlink_msg(const mavlink_channel_t &chan, const mavlink_message_t *mav_msg,
     AP_AHRS &ahrs)
@@ -391,4 +392,10 @@ void AC_Planck::override_with_zero_att_cmd() {
   _cmd.type = ATTITUDE;
   _cmd.timestamp_ms = AP_HAL::millis();
   _cmd.is_new = true;
+}
+
+void AC_Planck::record_hover_throttle() {
+  if(!is_tether_high_tension() && !is_tether_timed_out()) {
+    _hover_throttle_before_high_tension = AP_Motors::get_singleton()->get_throttle_hover();
+  }
 }

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -399,3 +399,7 @@ void AC_Planck::record_hover_throttle() {
     _hover_throttle_before_high_tension = AP_Motors::get_singleton()->get_throttle_hover();
   }
 }
+
+float AC_Planck::calculate_pos_throttle(const float boost_pct) {
+  return constrain_float(_hover_throttle_before_high_tension + boost_pct, _hover_throttle_before_high_tension, 1.);
+}

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -372,7 +372,7 @@ bool AC_Planck::check_for_high_tension_timeout() {
   //The amount of time to wait for high tension to timeout is a function of
   //initial altitude when the high tension event ocurred. Use tag altitude if available
   float timeout_s = 0;
-  const float reel_rate_cms = 60.96; //~2ft/s
+  const float reel_rate_cms = 38.1; //~1.25ft/s
   if(!is_equal(_tether_status.high_tension_tag_alt_cm,0.0f)) {
     timeout_s = _tether_status.high_tension_tag_alt_cm / reel_rate_cms;
   } else {

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -90,6 +90,12 @@ public:
   //Override any commands from ACE with zero-attitude commands
   void override_with_zero_att_cmd();
 
+  //Record the hover throttle position. Call this regularly
+  void record_hover_throttle();
+
+  //Get the recorded hover throttle prior to high tension events
+  float get_hover_throttle_before_high_tension() { return _hover_throttle_before_high_tension; };
+
 private:
 
   struct
@@ -143,6 +149,8 @@ private:
     float high_tension_alt_cm = 0;
     bool sent_failed_message = false;
   }_tether_status;
+
+  float _hover_throttle_before_high_tension = 0.5;
 
   mavlink_channel_t _chan = MAVLINK_COMM_1;
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -76,7 +76,7 @@ public:
   Vector3f get_tag_att(){return _tag_est.tag_att_cd;};
 
   //Tether timed out
-  bool is_tether_timed_out() { return ((AP_HAL::millis() - _tether_status.timestamp_ms) > 5000); };
+  bool is_tether_timed_out();
 
   //Tether high tension
   bool is_tether_high_tension() { return _tether_status.high_tension; };
@@ -148,6 +148,7 @@ private:
     float high_tension_tag_alt_cm =0;
     float high_tension_alt_cm = 0;
     bool sent_failed_message = false;
+    bool comms_timed_out = false;
   }_tether_status;
 
   float _hover_throttle_before_high_tension = 0.5;

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -90,12 +90,6 @@ public:
   //Override any commands from ACE with zero-attitude commands
   void override_with_zero_att_cmd();
 
-  //Record the hover throttle position. Call this regularly
-  void record_hover_throttle();
-
-  //Calculate the desired pos throttle for high tension events
-  float calculate_pos_throttle(const float boost_pct);
-
 private:
 
   struct

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -90,6 +90,9 @@ public:
   //Tether tag altitude on high-tension entry. 0 if not high tension or wasn't tracking tag
   float get_high_tension_entry_tag_alt_cm() { return _tether_status.high_tension_tag_alt_cm; };
 
+  //Determine if the tether tensioner may have failed
+  bool check_if_high_tension_failed(const int32_t alt_cm);
+
 private:
 
   struct

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -82,7 +82,7 @@ public:
   bool is_tether_high_tension() { return _tether_status.high_tension; };
 
   //Determine if the tether tensioner may have failed
-  bool check_if_high_tension_failed(const int32_t alt_cm);
+  bool check_for_high_tension_timeout();
 
   //Override any commands from ACE with zero-velocity commands
   void override_with_zero_vel_cmd();

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -93,8 +93,8 @@ public:
   //Record the hover throttle position. Call this regularly
   void record_hover_throttle();
 
-  //Get the recorded hover throttle prior to high tension events
-  float get_hover_throttle_before_high_tension() { return _hover_throttle_before_high_tension; };
+  //Calculate the desired pos throttle for high tension events
+  float calculate_pos_throttle(const float boost_pct);
 
 private:
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -136,6 +136,7 @@ private:
     uint32_t high_tension_timestamp_ms = 0;
     float high_tension_tag_alt_cm =0;
     float high_tension_alt_cm = 0;
+    bool sent_failed_message = false;
   }_tether_status;
 
   mavlink_channel_t _chan = MAVLINK_COMM_1;

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -75,6 +75,21 @@ public:
   //Get tag attitude
   Vector3f get_tag_att(){return _tag_est.tag_att_cd;};
 
+  //Tether timed out
+  bool is_tether_timed_out() { return ((AP_HAL::millis() - _tether_status.timestamp_ms) > 5000); };
+
+  //Tether cable spool out
+  float get_tether_cable_out_m() { return _tether_status.cable_out_m; };
+
+  //Tether high tension
+  bool is_tether_high_tension() { return _tether_status.high_tension; };
+
+  //Tether altitude on high-tension entry. 0 if not high tension
+  float get_high_tension_entry_alt_cm() { return _tether_status.high_tension_alt_cm; };
+
+  //Tether tag altitude on high-tension entry. 0 if not high tension or wasn't tracking tag
+  float get_high_tension_entry_tag_alt_cm() { return _tether_status.high_tension_tag_alt_cm; };
+
 private:
 
   struct
@@ -109,6 +124,16 @@ private:
     Vector3f tag_att_cd = Vector3f(0,0,0);
     uint32_t timestamp_us = 0;
   }_tag_est;
+
+  struct
+  {
+    uint32_t timestamp_ms = 0;
+    float cable_out_m = 0;
+    bool high_tension = false;
+    uint32_t high_tension_timestamp_ms = 0;
+    float high_tension_tag_alt_cm =0;
+    float high_tension_alt_cm = 0;
+  }_tether_status;
 
   mavlink_channel_t _chan = MAVLINK_COMM_1;
 

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -78,17 +78,8 @@ public:
   //Tether timed out
   bool is_tether_timed_out() { return ((AP_HAL::millis() - _tether_status.timestamp_ms) > 5000); };
 
-  //Tether cable spool out
-  float get_tether_cable_out_m() { return _tether_status.cable_out_m; };
-
   //Tether high tension
   bool is_tether_high_tension() { return _tether_status.high_tension; };
-
-  //Tether altitude on high-tension entry. 0 if not high tension
-  float get_high_tension_entry_alt_cm() { return _tether_status.high_tension_alt_cm; };
-
-  //Tether tag altitude on high-tension entry. 0 if not high tension or wasn't tracking tag
-  float get_high_tension_entry_tag_alt_cm() { return _tether_status.high_tension_tag_alt_cm; };
 
   //Determine if the tether tensioner may have failed
   bool check_if_high_tension_failed(const int32_t alt_cm);

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -93,6 +93,12 @@ public:
   //Determine if the tether tensioner may have failed
   bool check_if_high_tension_failed(const int32_t alt_cm);
 
+  //Override any commands from ACE with zero-velocity commands
+  void override_with_zero_vel_cmd();
+
+  //Override any commands from ACE with zero-attitude commands
+  void override_with_zero_att_cmd();
+
 private:
 
   struct
@@ -105,6 +111,14 @@ private:
     uint32_t timestamp_ms = 0;
     bool is_new = false;
     cmd_type type = NONE;
+    void zero() {
+      pos.zero();
+      vel_cms.zero();
+      accel_cmss.zero();
+      att_cd.zero();
+      is_yaw_rate = true;
+      type = NONE;
+    }
   }_cmd;
 
   struct

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -446,6 +446,9 @@ protected:
 
     void manual_override(RC_Channel *c, int16_t value_in, uint16_t offset, float scaler, const uint32_t tnow, bool reversed = false);
 
+    //Get planck ptr
+    virtual void* get_planck_ptr() { return nullptr; };
+
 private:
 
     // reduce effect of vehicle Yaw and gimbal pitch with increasing camera zoom

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -63,6 +63,7 @@
 
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AC_Planck/AC_Planck.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -2193,7 +2194,13 @@ void GCS_MAVLINK::send_planck_stateinfo()
     if(landed_state() != MAV_LANDED_STATE_ON_GROUND)
       status |= 0x02;
 
-    if(vehicle_system_status() == MAV_STATE_CRITICAL)
+    AC_Planck* planck = (AC_Planck*)get_planck_ptr();
+    bool tether_high_tension = false;
+    if(planck) {
+      tether_high_tension = planck->is_tether_high_tension() || planck->is_tether_timed_out();
+    }
+
+    if(vehicle_system_status() == MAV_STATE_CRITICAL || tether_high_tension)
       status |= 0x04;
 
     const AP_AHRS &ahrs = AP::ahrs();


### PR DESCRIPTION
[AVEM-831](https://planckaero.atlassian.net/browse/AVEM-831?atlOrigin=eyJpIjoiMGRkOTk3YzRlOWIzNDQ2ZDhmZTQ0NGIyNmNlNTFlZDMiLCJwIjoiaiJ9)

Adds the ability to detect high-tension events from the DECK, or detect loss of comms with the DECK, triggering landings.

In both cases, a "positive-throttle" method is emplaced, whereby lateral commands from ACE (either tag-based or GPS-based) will be used, but the z control is replaced by fixed throttle value slightly above the calculated hover throttle value.  This results in pull-down landings that generally look quite good.

Also adds detection of a high-tension failure (e.g. the spool fails). In such an event APM switches to standard APM:Land mode.

NOTE: This does not (yet) override APM:Land gps-enabled mode with a zero-velocity command.