### PR TITLE
Emit a heartbeat on motor kill command

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1406,6 +1406,9 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_flight_termination(const mavlink_command_l
     }
 #endif
 
+    //Immediately emit a heartbeat indicating a disarmed state
+    send_heartbeat();
+
     return result;
 }
 


### PR DESCRIPTION
[AVEM-844](https://planckaero.atlassian.net/browse/AVEM-844?atlOrigin=eyJpIjoiYzVlZTJiZWI3MTU0NDFiM2IzYTExODM0YmEzOGNhMzQiLCJwIjoiaiJ9)

Emits a heartbeat as soon as a FLIGHTTERMINATION command is received (which is what ACE sends on landing). This should result in a much lower latency indication of disarming.