### PR TITLE
Reset yaw mode when  exting planck a mode

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -380,7 +380,12 @@ void Copter::exit_mode(Mode *&old_flightmode,
     if (old_flightmode == &mode_planckland || old_flightmode == &mode_planckrtb) {
         mode_planckland.exit();
     }
-
+    if (old_flightmode == &mode_plancktracking) {
+        mode_plancktracking.exit();
+    }
+    if (old_flightmode == &mode_planckwingman){
+        mode_planckwingman.exit();
+    }
 #if FRAME_CONFIG == HELI_FRAME
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_flightmode == &mode_acro) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1516,6 +1516,7 @@ public:
     virtual bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool do_user_takeoff_start(float final_alt_above_home) override;
     bool requires_planck() const override { return true; }
+    void exit();
 
 protected:
 
@@ -1541,6 +1542,7 @@ public:
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
     bool is_landing() const override { return _is_landing; }
+    void exit();
 
 protected:
 
@@ -1588,6 +1590,7 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; }
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
+    void exit();
 
 protected:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1525,6 +1525,8 @@ protected:
 
     //if we want to land or transition to planck_land when we get back
     bool _land_when_ready = false;
+    autopilot_yaw_mode _stored_yaw_mode = auto_yaw.default_mode(false);
+
 };
 
 class ModePlanckRTB : public ModeGuided {
@@ -1550,6 +1552,7 @@ protected:
     const char *name4() const override { return "PRTB"; }
 
     bool _is_landing = false;
+    autopilot_yaw_mode _stored_yaw_mode = auto_yaw.default_mode(false);
 };
 
 class ModePlanckLand : public ModeGuidedNoGPS {
@@ -1574,6 +1577,8 @@ protected:
 
     const char *name() const override { return "PLANCKLAND"; }
     const char *name4() const override { return "PLND"; }
+    autopilot_yaw_mode _stored_yaw_mode = auto_yaw.default_mode(false);
+
 };
 
 class ModePlanckWingman : public ModeGuided {
@@ -1601,4 +1606,5 @@ private:
 
     uint32_t _next_req_send_t_ms = 0; //For sending new targets at a fixed rate
     const int8_t _send_rate_ms = 100; //10hz, 100ms
+    autopilot_yaw_mode _stored_yaw_mode = auto_yaw.default_mode(false);
 };

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -29,6 +29,7 @@ bool ModePlanckLand::init(bool ignore_checks){
 void ModePlanckLand::exit()
 {
     copter.pos_control->get_pos_z_p().kP(_kpz_nom);
+    auto_yaw.set_mode_to_default(false);
 }
 
 void ModePlanckLand::run(){

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -5,6 +5,7 @@ bool ModePlanckLand::init(bool ignore_checks){
     //If we are already landed this makes no sense
     if(copter.ap.land_complete)
       return false;
+    gcs().send_text(MAV_SEVERITY_INFO, "EnPL: symode from %d to %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
 
     _stored_yaw_mode = auto_yaw.mode();
 
@@ -31,6 +32,8 @@ bool ModePlanckLand::init(bool ignore_checks){
 void ModePlanckLand::exit()
 {
     copter.pos_control->get_pos_z_p().kP(_kpz_nom);
+    gcs().send_text(MAV_SEVERITY_INFO, "EPL: ymode to %d from %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
+
     auto_yaw.set_mode(_stored_yaw_mode);
 }
 

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -20,6 +20,7 @@ bool ModePlanckLand::init(bool ignore_checks){
             copter.g.land_speed : copter.pos_control->get_max_speed_down()))/100.;
       copter.planck_interface.request_land(land_velocity);
       copter.pos_control->get_pos_z_p().kP(g.planck_land_kp_z);
+      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
     return false;
@@ -29,7 +30,7 @@ bool ModePlanckLand::init(bool ignore_checks){
 void ModePlanckLand::exit()
 {
     copter.pos_control->get_pos_z_p().kP(_kpz_nom);
-    auto_yaw.set_mode_to_default(false);
+    auto_yaw.set_mode(_stored_yaw_mode);
 }
 
 void ModePlanckLand::run(){

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -6,6 +6,8 @@ bool ModePlanckLand::init(bool ignore_checks){
     if(copter.ap.land_complete)
       return false;
 
+    _stored_yaw_mode = auto_yaw.mode();
+
     if(!is_equal(copter.pos_control->get_pos_z_p().kP().get(),_kpz_nom)){
       _kpz_nom = copter.pos_control->get_pos_z_p().kP().get();
     }
@@ -20,7 +22,6 @@ bool ModePlanckLand::init(bool ignore_checks){
             copter.g.land_speed : copter.pos_control->get_max_speed_down()))/100.;
       copter.planck_interface.request_land(land_velocity);
       copter.pos_control->get_pos_z_p().kP(g.planck_land_kp_z);
-      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
     return false;

--- a/ArduCopter/mode_planckrtb.cpp
+++ b/ArduCopter/mode_planckrtb.cpp
@@ -33,3 +33,8 @@ void ModePlanckRTB::run(){
     }
     copter.mode_plancktracking.run();
 }
+
+void ModePlanckRTB::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}

--- a/ArduCopter/mode_planckrtb.cpp
+++ b/ArduCopter/mode_planckrtb.cpp
@@ -6,6 +6,8 @@ bool ModePlanckRTB::init(bool ignore_checks){
     if(copter.ap.land_complete)
       return false;
 
+    gcs().send_text(MAV_SEVERITY_INFO, "Entering Planck RTB: storing yaw mode from %d to %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
+
     _stored_yaw_mode = auto_yaw.mode();
 
     //If we're ready to land, jump right to it
@@ -38,5 +40,7 @@ void ModePlanckRTB::run(){
 
 void ModePlanckRTB::exit()
 {
+  gcs().send_text(MAV_SEVERITY_INFO, "Exiting RTB: setting yaw mode to %d from %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
+
   auto_yaw.set_mode(_stored_yaw_mode);
 }

--- a/ArduCopter/mode_planckrtb.cpp
+++ b/ArduCopter/mode_planckrtb.cpp
@@ -9,12 +9,14 @@ bool ModePlanckRTB::init(bool ignore_checks){
     //If we're ready to land, jump right to it
     if(copter.mode_planckland.init(ignore_checks)) {
       _is_landing = true;
+      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 
     //Otherwise, run tracking
     if(copter.mode_plancktracking.init(ignore_checks)) {
       _is_landing = false;
+      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 

--- a/ArduCopter/mode_planckrtb.cpp
+++ b/ArduCopter/mode_planckrtb.cpp
@@ -6,17 +6,17 @@ bool ModePlanckRTB::init(bool ignore_checks){
     if(copter.ap.land_complete)
       return false;
 
+    _stored_yaw_mode = auto_yaw.mode();
+
     //If we're ready to land, jump right to it
     if(copter.mode_planckland.init(ignore_checks)) {
       _is_landing = true;
-      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 
     //Otherwise, run tracking
     if(copter.mode_plancktracking.init(ignore_checks)) {
       _is_landing = false;
-      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 
@@ -38,5 +38,5 @@ void ModePlanckRTB::run(){
 
 void ModePlanckRTB::exit()
 {
-  auto_yaw.set_mode_to_default(false);
+  auto_yaw.set_mode(_stored_yaw_mode);
 }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -347,3 +347,7 @@ bool ModePlanckTracking::allows_arming(bool from_gcs) const
     return true;
 }
 
+void ModePlanckTracking::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -29,6 +29,8 @@ bool ModePlanckTracking::init(bool ignore_checks){
           rate_xy_cms/100.);
     }
 
+    gcs().send_text(MAV_SEVERITY_INFO, "EnPT: symode from %d to %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
+
     _stored_yaw_mode = auto_yaw.mode();
     //Initialize the GUIDED methods
     return init_without_RTB_request(ignore_checks);
@@ -131,6 +133,11 @@ void ModePlanckTracking::run() {
         }
     }
 
+    static uint32_t next_yaw_report_t_ms = 0;
+           if(AP_HAL::millis() > next_yaw_report_t_ms) {
+             gcs().send_text(MAV_SEVERITY_INFO, "yfmode pan ymode:  %i %i %i",  mount->mount_yaw_follow_mode, mount->has_pan_control(), auto_yaw.mode());
+             next_yaw_report_t_ms = AP_HAL::millis() + 500;
+           }
     //If there is new command data, send it to Guided
     if(copter.planck_interface.new_command_available()) {
         switch(copter.planck_interface.get_cmd_type()) {
@@ -350,5 +357,6 @@ bool ModePlanckTracking::allows_arming(bool from_gcs) const
 
 void ModePlanckTracking::exit()
 {
+  gcs().send_text(MAV_SEVERITY_INFO, "EPT: ymode to %d from %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
   auto_yaw.set_mode(_stored_yaw_mode);
 }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -29,6 +29,7 @@ bool ModePlanckTracking::init(bool ignore_checks){
           rate_xy_cms/100.);
     }
 
+    _stored_yaw_mode = auto_yaw.mode();
     //Initialize the GUIDED methods
     return init_without_RTB_request(ignore_checks);
 }
@@ -349,5 +350,5 @@ bool ModePlanckTracking::allows_arming(bool from_gcs) const
 
 void ModePlanckTracking::exit()
 {
-  auto_yaw.set_mode_to_default(false);
+  auto_yaw.set_mode(_stored_yaw_mode);
 }

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -47,3 +47,8 @@ void ModePlanckWingman::run() {
 
   copter.mode_plancktracking.run();
 }
+
+void ModePlanckWingman::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -10,11 +10,12 @@ bool ModePlanckWingman::init(bool ignore_checks){
       return false;
 
     //Otherwise, run tracking
+    _stored_yaw_mode = auto_yaw.mode();
+
     if(copter.mode_plancktracking.init_without_RTB_request(ignore_checks)) {
 
       //And command a zero-rate, telling planck to maintain current relative position
       copter.planck_interface.request_move_target(Vector3f(0,0,0),true);
-      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -14,6 +14,7 @@ bool ModePlanckWingman::init(bool ignore_checks){
 
       //And command a zero-rate, telling planck to maintain current relative position
       copter.planck_interface.request_move_target(Vector3f(0,0,0),true);
+      _stored_yaw_mode = auto_yaw.mode();
       return true;
     }
 
@@ -50,5 +51,5 @@ void ModePlanckWingman::run() {
 
 void ModePlanckWingman::exit()
 {
-  auto_yaw.set_mode_to_default(false);
+  auto_yaw.set_mode(_stored_yaw_mode);
 }

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -52,5 +52,6 @@ void ModePlanckWingman::run() {
 
 void ModePlanckWingman::exit()
 {
+  gcs().send_text(MAV_SEVERITY_INFO, "Exiting Planck Wingman: setting yaw mode to %d from %d", (unsigned)_stored_yaw_mode,(unsigned)auto_yaw.mode());
   auto_yaw.set_mode(_stored_yaw_mode);
 }


### PR DESCRIPTION
This PR sets the auto_yaw mode to default whenever a planck mode is exited. This prevents the current yaw mode from latching, causing issues in the new mode if the new mode doesn't set it's own yaw mode. Specifically, since the payload yaw control architecture requires the yaw mode to be AUTO_YAW_FIXED, then if the user changes to stabilize, the yaw mode will remain in AUTO_YAW_FIXED, and the user will not have control of yaw. This PR fixes that by changing to the default yaw mode, which gives the user yaw control (yaw control is given to user in stabilize in all auto yaw modes except AUTO_YAW_FIXED)