### PR TITLE
Planck copter 4.0.3 avem indago yaw mode

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -380,7 +380,12 @@ void Copter::exit_mode(Mode *&old_flightmode,
     if (old_flightmode == &mode_planckland || old_flightmode == &mode_planckrtb) {
         mode_planckland.exit();
     }
-
+    if (old_flightmode == &mode_plancktracking) {
+        mode_plancktracking.exit();
+    }
+    if (old_flightmode == &mode_planckwingman ) {
+        mode_planckwingman.exit();
+    }
 #if FRAME_CONFIG == HELI_FRAME
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_flightmode == &mode_acro) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1516,6 +1516,7 @@ public:
     virtual bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool do_user_takeoff_start(float final_alt_above_home) override;
     bool requires_planck() const override { return true; }
+    void exit();
 
 protected:
 
@@ -1541,6 +1542,7 @@ public:
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
     bool is_landing() const override { return _is_landing; }
+    void exit();
 
 protected:
 
@@ -1588,6 +1590,7 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; }
     bool is_autopilot() const override { return true; }
     bool requires_planck() const override { return true; }
+    void exit();
 
 protected:
 

--- a/ArduCopter/mode_planckland.cpp
+++ b/ArduCopter/mode_planckland.cpp
@@ -29,6 +29,7 @@ bool ModePlanckLand::init(bool ignore_checks){
 void ModePlanckLand::exit()
 {
     copter.pos_control->get_pos_z_p().kP(_kpz_nom);
+    auto_yaw.set_mode_to_default(false);
 }
 
 void ModePlanckLand::run(){

--- a/ArduCopter/mode_planckrtb.cpp
+++ b/ArduCopter/mode_planckrtb.cpp
@@ -33,3 +33,8 @@ void ModePlanckRTB::run(){
     }
     copter.mode_plancktracking.run();
 }
+
+void ModePlanckRTB::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -347,3 +347,7 @@ bool ModePlanckTracking::allows_arming(bool from_gcs) const
     return true;
 }
 
+void ModePlanckTracking::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}

--- a/ArduCopter/mode_planckwingman.cpp
+++ b/ArduCopter/mode_planckwingman.cpp
@@ -47,3 +47,8 @@ void ModePlanckWingman::run() {
 
   copter.mode_plancktracking.run();
 }
+
+void ModePlanckWingman::exit()
+{
+  auto_yaw.set_mode_to_default(false);
+}


### PR DESCRIPTION
This PR sets the auto_yaw mode to default whenever a planck mode is exited. This prevents the current yaw mode from latching, causing issues in the new mode if the new mode doesn't set it's own yaw mode. Specifically, since the payload yaw control architecture requires the yaw mode to be AUTO_YAW_FIXED, then if the user changes to stabilize, the yaw mode will remain in AUTO_YAW_FIXED, and the user will not have control of yaw. This PR fixes that by changing to the default yaw mode, which gives the user yaw control (yaw control is given to user in stabilize in all auto yaw modes except AUTO_YAW_FIXED)