### PR TITLE
[ACE-965] add timeout to new_command_available check

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -814,6 +814,8 @@ public:
 
     void angle_control_start();
     void angle_control_run(bool high_jerk_z = false);
+    void reset_update_times();
+    bool should_reset_update_times();
 
 protected:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -814,8 +814,7 @@ public:
 
     void angle_control_start();
     void angle_control_run(bool high_jerk_z = false);
-    void reset_update_times();
-    bool should_reset_update_times();
+    void check_and_reset_update_times();
 
 protected:
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -788,4 +788,16 @@ float ModeGuided::crosstrack_error() const
     }
 }
 
+void ModeGuided::reset_update_times()
+{
+    vel_update_time_ms = 0;
+    posvel_update_time_ms = 0;
+    guided_angle_state.update_time_ms = 0;
+}
+
+bool ModeGuided::should_reset_update_times()
+{
+    return (vel_update_time_ms > 0) || (posvel_update_time_ms > 0) || (guided_angle_state.update_time_ms > 0);
+}
+
 #endif

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -788,6 +788,7 @@ float ModeGuided::crosstrack_error() const
     }
 }
 
+// set all update times to 0 - can be used to trigger timeouts immediately
 void ModeGuided::reset_update_times()
 {
     vel_update_time_ms = 0;
@@ -795,6 +796,7 @@ void ModeGuided::reset_update_times()
     guided_angle_state.update_time_ms = 0;
 }
 
+// don't reset update times if they are all 0
 bool ModeGuided::should_reset_update_times()
 {
     return (vel_update_time_ms > 0) || (posvel_update_time_ms > 0) || (guided_angle_state.update_time_ms > 0);

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -788,18 +788,15 @@ float ModeGuided::crosstrack_error() const
     }
 }
 
-// set all update times to 0 - can be used to trigger timeouts immediately
-void ModeGuided::reset_update_times()
+// set all update times to 0 if at least one has updated - can be used to trigger timeouts immediately
+void ModeGuided::check_and_reset_update_times()
 {
+  if((vel_update_time_ms > 0) || (posvel_update_time_ms > 0) || (guided_angle_state.update_time_ms > 0))
+  {
     vel_update_time_ms = 0;
     posvel_update_time_ms = 0;
     guided_angle_state.update_time_ms = 0;
-}
-
-// don't reset update times if they are all 0
-bool ModeGuided::should_reset_update_times()
-{
-    return (vel_update_time_ms > 0) || (posvel_update_time_ms > 0) || (guided_angle_state.update_time_ms > 0);
+  }
 }
 
 #endif

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -192,6 +192,13 @@ void ModePlanckTracking::run() {
             break;
       }
     }
+    else if(copter.planck_interface.command_timed_out())
+    {
+        if(should_reset_update_times())
+        {
+            copter.mode_guided.reset_update_times();
+        }
+    }
 
     //Run the guided mode controller
     ModeGuided::run(true); //use high-jerk

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -195,10 +195,7 @@ void ModePlanckTracking::run() {
     // If ACE stopped sending commands, reset guided mode update times so guided timeout triggers immediately
     else if(copter.planck_interface.command_timed_out())
     {
-        if(should_reset_update_times())
-        {
-            copter.mode_guided.reset_update_times();
-        }
+        copter.mode_guided.check_and_reset_update_times();
     }
 
     //Run the guided mode controller

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -192,6 +192,7 @@ void ModePlanckTracking::run() {
             break;
       }
     }
+    // If ACE stopped sending commands, reset guided mode update times so guided timeout triggers immediately
     else if(copter.planck_interface.command_timed_out())
     {
         if(should_reset_update_times())

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -287,6 +287,7 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
 
 bool AC_Planck::new_command_available()
 {
+  // not a new command if it's more than 100 ms old
   if (_cmd.is_new && command_timed_out())
     _cmd.is_new = false;
 
@@ -295,5 +296,6 @@ bool AC_Planck::new_command_available()
 
 bool AC_Planck::command_timed_out()
 {
+  // _cmd is timed out if it's been set and is more than 100 ms old
   return ((AP_HAL::millis() -_cmd.timestamp_ms) > 100) && (_cmd.timestamp_ms > 0);
 };

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -285,9 +285,9 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
   return muxed_rates;
 };
 
-bool new_command_available()
+bool AC_Planck::new_command_available()
 {
-  if ((_cmd.timestamp_ms - AP_HAL::millis()) > 100)
+  iif ((AP_HAL::millis() -_cmd.timestamp_ms) > 100)
     _cmd.is_new = false;
 
   return _cmd.is_new;

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -287,8 +287,13 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
 
 bool AC_Planck::new_command_available()
 {
-  if (_cmd.is_new && ((AP_HAL::millis() -_cmd.timestamp_ms) > 100))
+  if (_cmd.is_new && command_timed_out())
     _cmd.is_new = false;
 
   return _cmd.is_new;
+};
+
+bool AC_Planck::command_timed_out()
+{
+  return ((AP_HAL::millis() -_cmd.timestamp_ms) > 100) && (_cmd.timestamp_ms > 0);
 };

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -287,7 +287,7 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
 
 bool AC_Planck::new_command_available()
 {
-  iif ((AP_HAL::millis() -_cmd.timestamp_ms) > 100)
+  if (_cmd.is_new && ((AP_HAL::millis() -_cmd.timestamp_ms) > 100))
     _cmd.is_new = false;
 
   return _cmd.is_new;

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -115,6 +115,7 @@ void AC_Planck::handle_planck_mavlink_msg(const mavlink_channel_t &chan, const m
 
         //This is a new command
         _cmd.is_new = true;
+        _cmd.timestamp_ms = AP_HAL::millis();
         break;
     }
 
@@ -282,4 +283,12 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
   uint32_t muxed_rates = ((uint32_t(rate_up) << 16) | uint32_t(rate_down));
   muxed_rates = (muxed_rates & 0x7FFF7FFF) | 0x00008000;
   return muxed_rates;
+};
+
+bool new_command_available()
+{
+  if ((_cmd.timestamp_ms - AP_HAL::millis()) > 100)
+    _cmd.is_new = false;
+
+  return _cmd.is_new;
 };

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -50,6 +50,7 @@ public:
   //command getters
   cmd_type get_cmd_type(void) { return _cmd.type; }
   bool new_command_available();
+  bool command_timed_out();
 
   //Get an accel, yaw, z_rate command
   bool get_accel_yaw_zrate_cmd(Vector3f &accel_cmss, float &yaw_cd, float &vz_cms, bool &is_yaw_rate);

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -49,7 +49,7 @@ public:
 
   //command getters
   cmd_type get_cmd_type(void) { return _cmd.type; }
-  bool new_command_available() { return _cmd.is_new; };
+  bool new_command_available();
 
   //Get an accel, yaw, z_rate command
   bool get_accel_yaw_zrate_cmd(Vector3f &accel_cmss, float &yaw_cd, float &vz_cms, bool &is_yaw_rate);


### PR DESCRIPTION
This PR adds a timeout to the new_command_available() check in AC_Planck. Specifically, it sets _cmd.is_new = false if the timestamp of _cmd is older than 100 ms. 

EDIT: I've added more functionality to this PR. It now, additionally, resets the guided mode update times to 0 if APM stops receiving ACE commands while running mode_plancktracking::run(). This will fix cases for https://planckaero.atlassian.net/browse/ACE-965, eg Saitotec, that weren't addressed by the earlier version of this PR

Addresses https://planckaero.atlassian.net/browse/ACE-965 and partially helps with https://planckaero.atlassian.net/browse/ACE-976