### PR TITLE
[AVEM-1094] Planck copter 4.0.3 avem indago yaw rate units

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -89,7 +89,7 @@ void ModePlanckTracking::run() {
           else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
           {
             copter.flightmode->auto_yaw.set_fixed_yaw(
-                  copter.flightmode->auto_yaw.rate_cds(),
+                  copter.flightmode->auto_yaw.rate_cds()/100.f,
                   0.0f,
                   0,
                   0);


### PR DESCRIPTION
This PR fixes an error where the set_fixed_yaw() function was passed and argument in units of centi-degrees/sec, where it should have been passed units of degrees/sec. Furthermore, set_fixed_yaw() wraps the value from 0-360, when a rate command should not be wrapped at all. 

The proposed resolution writes the received yaw rate command to a separate variable "yaw_rate_cmd_cds", and calls set_fixed_yaw() with the current heading as its argument. In the proposed change, set_fixed_yaw() is only called to change the autoyaw mode to  AUTO_YAW_FIXED (which is necessary for the current yaw rate logic to work), and to update the timestamp to prevent timeouts. 

The new variable, "yaw_rate_cmd_cds", is then used only when "paylod_yaw_rate" is true, otherwise the value of copter.flightmode->auto_yaw.yaw() is used, as it is currently