### PR TITLE
[AVEM-1232] support tablet yaw rate commands in posvel

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -37,7 +37,9 @@ void ModePlanckTracking::run() {
 
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
-    bool paylod_yaw_rate = false;
+    bool is_paylod_yaw_rate = false;
+    bool use_paylod_yaw_rate = false;
+    float payload_yaw_rate_cds = 0;
 
     //Check for tether high tension
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
@@ -67,7 +69,7 @@ void ModePlanckTracking::run() {
                   direction,
                   relative_angle);
           }
-          paylod_yaw_rate = false;
+          is_paylod_yaw_rate = false;
         }
         else if(!mount->has_pan_control() || mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
         {
@@ -75,25 +77,38 @@ void ModePlanckTracking::run() {
           //so we set the set the fixed yaw command to this rate, and tell the
           //angle controller in mode guided to interpret as a rate. Note that the
           //auto yaw will be set to mode fixed, though it is actually controlling rate.
-          paylod_yaw_rate = true;
+          is_paylod_yaw_rate = true;
 
-          //If we've stopped getting the mavlink yaw rate commands, use 0 yaw rate command
-          if(AP_HAL::micros64() - mount->get_last_mount_control_time_us() > 500000)
+          if(copter.mode_guided.mode()==Guided_Angle)
           {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                  0.0f,
-                  0.0f,
-                  0,
-                  0);
+            //If we've stopped getting the mavlink yaw rate commands, use 0 yaw rate command
+            if(AP_HAL::micros64() - (mount->get_last_mount_control_time_us() > 500000))
+            {
+              copter.flightmode->auto_yaw.set_fixed_yaw(
+                    0.0f,
+                    0.0f,
+                    0,
+                    0);
+            }
+            else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
+            {
+              copter.flightmode->auto_yaw.set_fixed_yaw(
+                    copter.flightmode->auto_yaw.rate_cds(),
+                    0.0f,
+                    0,
+                    0);
+
+            }
           }
-          else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
+          else
           {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                  copter.flightmode->auto_yaw.rate_cds(),
-                  0.0f,
-                  0,
-                  0);
-
+            //if we have tablet rate commands have been received and are not stale, and we're in posvel,
+            //then use tablet (payload) yaw rate commands instead of ACE yaw/yaw rate commands
+            if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE && (AP_HAL::micros64() - (mount->get_last_mount_control_time_us() <= 500000)))
+            {
+               payload_yaw_rate_cds = copter.flightmode->auto_yaw.rate_cds();
+               use_paylod_yaw_rate = true;
+            }
           }
         }
       }
@@ -177,7 +192,7 @@ void ModePlanckTracking::run() {
                       && !high_tension)
               {
                   yaw_cd = copter.flightmode->auto_yaw.yaw();
-                  is_yaw_rate = paylod_yaw_rate;
+                  is_yaw_rate = is_paylod_yaw_rate;
               }
 
               //Convert this to quaternions, yaw rates
@@ -286,7 +301,14 @@ void ModePlanckTracking::run() {
                           pos_cmd.z = new_alt_cm;
                       }
                   }
-                  if(is_yaw_rate)
+
+                  //use payload yaw rate if we have it
+                  if(use_paylod_yaw_rate && is_paylod_yaw_rate)
+                  {
+                    yaw_rate_cmd = payload_yaw_rate_cds;
+                    is_yaw_rate = use_paylod_yaw_rate;
+                  }
+                  else if(is_yaw_rate)
                   {
                     yaw_rate_cmd = yaw_cmd;
                   }


### PR DESCRIPTION
This PR forces the yaw controller to use yaw (or yaw rate) commands from the ACE command message when the guided_mode is not "Guided_Angle". This is necessary because, if guided_mode is posvel, for example, the current architecture will interpret all commands as angles, rather than angle rates (due to the use of set_fixed_yaw(), which is a necessary hack/workaroud to let the payload control yaw). 

The problem with the current code is that mode_guided yaw control has different behavior in Guided_Angle; it gets the yaw command from auto_yaw.yaw() regardless of the auto_yaw mode. In this application, we tell it to interpret that command as a rate with a flag, not the auto_yaw mode  In, say, Guided_PosVel, the yaw command depends on the auto_yaw mode. Furthermore, it interprets commands as an angle or rate based on the auto_yaw mode, not a flag.  Because we use set_fixed_yaw() as a workaround, the auto_yaw mode will be AUTO_YAW_FIXED, and the yaw controller will interpret commands as angles always. Finally, the set_fixed_yaw() will get called at 400 hz, regardless of whether a new ACE command is received. This overrides any change to the auto_yaw mode that result from the ACE command, ie when set_destination_posvel() is called, which is at 50 hz. 

So, this PR will prevent the use of set_fixed_yaw() when guided_mode is not  Guided_Angle.

Specifically, this PR will:
- use the current architecture with "set_fixed_yaw()" if guided_mode Guided_Angle
- if guided mode is NOT Guided_Angle, but yaw rate commands from the tablet are present and not stale, then the tablet yaw rate commands are used for the yaw controller
-  if guided mode is NOT Guided_Angle, and NO valid/recent rate commands from the tablet are present, then the ACE yaw/yaw rate command is used.
- Note this prevents odd/broken behavior when it is configured to have a gimbal but none is present
- Note this also still allows the tablet to control yaw in Guided_PosVel


 