### PR TITLE
[AVEM-1094] Planck copter 4.0.7 avem indago yaw rate units

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -42,6 +42,7 @@ void ModePlanckTracking::run() {
     //Check for tether high tension
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
     bool use_positive_throttle = high_tension;
+    float yaw_rate_cmd_cds = 0;
 
     // Don't use/set heading command from gimbal if tether is in high tension.
     if(!high_tension)
@@ -86,10 +87,17 @@ void ModePlanckTracking::run() {
                   0,
                   0);
           }
+          //We've got a new yaw rate command from the tablet
           else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
           {
+            //Set the yaw rate command if using tablet rate commands (no gimbal pan)
+            //Note that the logic still requires auto yaw mode to be AUTO_YAW_FIXED
+            yaw_rate_cmd_cds = copter.flightmode->auto_yaw.rate_cds();
+
+            //call set_fixed_yaw() to set yaw mode to fixed, and update the time stamp so it doesn't time out
+            //the yaw angle command won't be used here, but set it to current yaw just in case
             copter.flightmode->auto_yaw.set_fixed_yaw(
-                  copter.flightmode->auto_yaw.rate_cds(),
+                  degrees(copter.ahrs.get_yaw()),
                   0.0f,
                   0,
                   0);
@@ -176,7 +184,7 @@ void ModePlanckTracking::run() {
                       && (copter.planck_interface.get_tag_pos().z > min_yaw_alt_cm)
                       && !high_tension)
               {
-                  yaw_cd = copter.flightmode->auto_yaw.yaw();
+                  yaw_cd = paylod_yaw_rate ? yaw_rate_cmd_cds : copter.flightmode->auto_yaw.yaw();
                   is_yaw_rate = paylod_yaw_rate;
               }
 


### PR DESCRIPTION
NOTE: Identical to https://github.com/planckaero/ardupilot/pull/46, except applied to planck_Copter-4.0.7_AVEMIndago instead of planck_Copter-4.0.3_AVEMIndago

This PR fixes an error where the set_fixed_yaw() function was passed and argument in units of centi-degrees/sec, where it should have been passed units of degrees/sec. Furthermore, set_fixed_yaw() wraps the value from 0-360, when a rate command should not be wrapped at all.

The proposed resolution writes the received yaw rate command to a separate variable "yaw_rate_cmd_cds", and calls set_fixed_yaw() with the current heading as its argument. In the proposed change, set_fixed_yaw() is only called to change the autoyaw mode to AUTO_YAW_FIXED (which is necessary for the current yaw rate logic to work), and to update the timestamp to prevent timeouts.

The new variable, "yaw_rate_cmd_cds", is then used only when "paylod_yaw_rate" is true, otherwise the value of copter.flightmode->auto_yaw.yaw() is used, as it is currently
