### PR TITLE
[GDARV-243 ] - I3 batt switch rev3 baseline

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -173,9 +173,12 @@ AP_BattMonitor::init()
                                                                  hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                          100000, true, 20));
 		break;
-            case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO:
+            case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO_REV2:
+            case AP_BattMonitor_Params::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO_REV3:
+
                 drivers[instance] = new AP_BattMonitor_Analog_GPIO(*this, state[instance], _params[instance],
-                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL, AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR,
+                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL,
+                                                                                          AP_BattMonitor_Analog_GPIO::get_I2C_addr(_params[instance].type()),
                                                                                             100000, true, 20));
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_NONE:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
@@ -4,8 +4,15 @@
 
 #define AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL           0
 #define AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL           1
-#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR               0x70 //PCAL9538APWJ
 #define AP_BATTMONITOR_ANALOG_GPIO_TIMEOUT_MICROS         5000000 // sensor becomes unhealthy if no successful readings for 5 seconds
+
+// Battery switch board rev 2
+#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR_REV2          0x49 //PCA9537
+#define AP_BATTMONITOR_FET_EN_TETHER_REV2                 0x04 //Bit 3 of register 0
+
+// Battery switch board rev 3
+#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR_REV3          0x70 //PCAL9538APWJ
+#define AP_BATTMONITOR_FET_EN_TETHER_REV3                 0x02 //Bit 1 of register 0
 
 class AP_BattMonitor_Analog_GPIO : public AP_BattMonitor_Analog {
 public:
@@ -23,9 +30,13 @@ public:
     /// returns true if battery monitor provides current info
     bool has_current() const override;
 
+    /// return the I2C device address
+    static uint8_t get_I2C_addr(const AP_BattMonitor_Params::BattMonitor_Type type);
+
 private:
   AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
   bool _is_using_battery = false;
+  uint8_t _use_tether_mask = 0x00;
 
   void timer();
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog_GPIO.h
@@ -4,7 +4,7 @@
 
 #define AP_BATTMONITOR_ANALOG_GPIO_BUS_INTERNAL           0
 #define AP_BATTMONITOR_ANALOG_GPIO_BUS_EXTERNAL           1
-#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR               0x49 //PCA9537
+#define AP_BATTMONITOR_ANALOG_GPIO_I2C_ADDR               0x70 //PCAL9538APWJ
 #define AP_BATTMONITOR_ANALOG_GPIO_TIMEOUT_MICROS         5000000 // sensor becomes unhealthy if no successful readings for 5 seconds
 
 class AP_BattMonitor_Analog_GPIO : public AP_BattMonitor_Analog {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -28,7 +28,8 @@ public:
         BattMonitor_TYPE_SUI3                       = 13,
         BattMonitor_TYPE_SUI6                       = 14,
         BattMonitor_TYPE_NeoDesign                  = 15,
-        BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO = 16,
+        BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO_REV2 = 16,
+        BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT_AND_GPIO_REV3 = 17
     };
 
     // low voltage sources (used for BATT_LOW_TYPE parameter)


### PR DESCRIPTION
[GDARV-243](https://planckaero.atlassian.net/browse/GDARV-243)

Initial support for battery switch rev3:
- battery voltage & current and tether power active
- APM `BATT_MONITOR=16` for rev2 and APM `BATT_MONITOR=17` for rev3



[GDARV-243]: https://planckaero.atlassian.net/browse/GDARV-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ