### PR TITLE
[GDARV-240] Add parm to expecetd HT teth spd, so timeout adjusts accordingly

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -437,6 +437,14 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(planck_high_tension_throttle, "PLANCK_HT_THR", PLANCK_HT_THR),
 
+    // @Param: planck_expected_tether_speed_cms
+    // @DisplayName: Planck High Tension Tether Speed
+    // @Description: Expected tether reel in rate during high tension
+    // @Units: cm/s
+    // @Range: 1 1000
+    // @User: Advanced
+    GSCALAR(planck_expected_tether_speed_cms, "PLANCK_HT_TETH_SPD", PLANCK_HT_TETH_SPD),
+
     // @Param: NAV_LEDS_ON
     // @DisplayName: Nav Lights On
     // @Description: Enable motor LED lights

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -226,6 +226,7 @@ public:
         k_param_planck_land_kp_z, // 127
         k_param_planck_high_tension_throttle, // 128
         k_param_nav_lights_on, // 129
+        k_param_planck_expected_tether_speed_cms, // 130
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -473,6 +474,7 @@ public:
     // planck Parameters
     AP_Float                planck_land_kp_z;
     AP_Float                planck_high_tension_throttle;
+    AP_Float                planck_expected_tether_speed_cms;
     AP_Int8                 nav_lights_on;
 
     // Note: keep initializers here in the same order as they are declared

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -806,3 +806,8 @@
 #ifndef PLANCK_HT_THR
  #define PLANCK_HT_THR              0.65 //65%
 #endif
+
+// Emergency Mode Tether Speed
+#ifndef PLANCK_HT_TETH_SPD
+ #define PLANCK_HT_TETH_SPD              38.1 //38.1 cm/s
+#endif

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -120,7 +120,7 @@ void ModePlanckTracking::run() {
             copter.set_mode_planck_RTB_or_planck_land(ModeReason::GCS_FAILSAFE);
         }
 
-        if(!copter.planck_interface.check_for_high_tension_timeout()) { //High tension hasn't failed
+        if(!copter.planck_interface.check_for_high_tension_timeout(copter.g.planck_expected_tether_speed_cms)) { //High tension hasn't failed
             //While in high tension:
             // - If actively tracking the tag, continue to do so, but use pos throttle
             // - If not tracking the tag, but have GPS, command zero velocity but use pos throttle

--- a/libraries/AC_Planck/AC_Planck.cpp
+++ b/libraries/AC_Planck/AC_Planck.cpp
@@ -361,7 +361,7 @@ uint32_t AC_Planck::mux_rates(float rate_up,  float rate_down)
   return muxed_rates;
 }
 
-bool AC_Planck::check_for_high_tension_timeout() {
+bool AC_Planck::check_for_high_tension_timeout(float ht_tether_spd) {
   //No failure if not flying
   if(AP_Motors::get_singleton()->get_spool_state() == AP_Motors::SpoolState::SHUT_DOWN) {
     return false;
@@ -382,7 +382,7 @@ bool AC_Planck::check_for_high_tension_timeout() {
   //The amount of time to wait for high tension to timeout is a function of
   //initial altitude when the high tension event ocurred. Use tag altitude if available
   float timeout_s = 0;
-  const float reel_rate_cms = 38.1; //~1.25ft/s
+  const float reel_rate_cms = std::fmaxf(1,ht_tether_spd); //~1.25ft/s
   if(!is_equal(_tether_status.high_tension_tag_alt_cm,0.0f)) {
     timeout_s = _tether_status.high_tension_tag_alt_cm / reel_rate_cms;
   } else {

--- a/libraries/AC_Planck/AC_Planck.h
+++ b/libraries/AC_Planck/AC_Planck.h
@@ -84,7 +84,7 @@ public:
   bool is_tether_high_tension() { return _tether_status.high_tension; };
 
   //Determine if the tether tensioner may have failed
-  bool check_for_high_tension_timeout();
+  bool check_for_high_tension_timeout(float ht_tether_spd);
 
   //Override any commands from ACE with zero-velocity commands
   void override_with_zero_vel_cmd();


### PR DESCRIPTION
[GDARV-240](https://planckaero.atlassian.net/browse/GDARV-240)

This PR adds an APM parameter for the expected tether reel-in speed during high tension. This value is currently hard coded to 38.1 cm/s, and is used to calculate the timeout (ie detect a BV failure) for HT descent. An adjustable value let's us tune for cases where the reel-in speed may be slower/longer, eg, using the thicker 200 ft tether. 