### PR TITLE
[AVEM-1408] Planck copter 4.0.7 avem indago gimbal message check

### DIFF
--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -37,7 +37,9 @@ void ModePlanckTracking::run() {
 
     // check if gimbal steering needs to controlling the vehicle yaw
     AP_Mount *mount = AP::mount();
-    bool paylod_yaw_rate = false;
+    bool is_paylod_yaw_rate = false;
+    bool use_paylod_yaw_rate = false;
+    float payload_yaw_rate_cds = 0;
 
     //Check for tether high tension
     bool high_tension = copter.planck_interface.is_tether_high_tension() || copter.planck_interface.is_tether_timed_out();
@@ -67,7 +69,7 @@ void ModePlanckTracking::run() {
                   direction,
                   relative_angle);
           }
-          paylod_yaw_rate = false;
+          is_paylod_yaw_rate = false;
         }
         else if(!mount->has_pan_control() || mount->mount_yaw_follow_mode == AP_Mount::gimbal_yaw_follows_vehicle)
         {
@@ -75,25 +77,38 @@ void ModePlanckTracking::run() {
           //so we set the set the fixed yaw command to this rate, and tell the
           //angle controller in mode guided to interpret as a rate. Note that the
           //auto yaw will be set to mode fixed, though it is actually controlling rate.
-          paylod_yaw_rate = true;
+          is_paylod_yaw_rate = true;
 
-          //If we've stopped getting the mavlink yaw rate commands, use 0 yaw rate command
-          if(AP_HAL::micros64() - mount->get_last_mount_control_time_us() > 500000)
+          if(copter.mode_guided.mode()==Guided_Angle)
           {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                  0.0f,
-                  0.0f,
-                  0,
-                  0);
+            //If we've stopped getting the mavlink yaw rate commands, use 0 yaw rate command
+            if(AP_HAL::micros64() - (mount->get_last_mount_control_time_us() > 500000))
+            {
+              copter.flightmode->auto_yaw.set_fixed_yaw(
+                    0.0f,
+                    0.0f,
+                    0,
+                    0);
+            }
+            else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
+            {
+              copter.flightmode->auto_yaw.set_fixed_yaw(
+                    copter.flightmode->auto_yaw.rate_cds(),
+                    0.0f,
+                    0,
+                    0);
+
+            }
           }
-          else if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE)
+          else
           {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                  copter.flightmode->auto_yaw.rate_cds(),
-                  0.0f,
-                  0,
-                  0);
-
+            //if we have tablet rate commands have been received and are not stale, and we're in posvel,
+            //then use tablet (payload) yaw rate commands instead of ACE yaw/yaw rate commands
+            if(copter.flightmode->auto_yaw.mode() == AUTO_YAW_RATE && (AP_HAL::micros64() - (mount->get_last_mount_control_time_us() <= 500000)))
+            {
+               payload_yaw_rate_cds = copter.flightmode->auto_yaw.rate_cds();
+               use_paylod_yaw_rate = true;
+            }
           }
         }
       }
@@ -177,7 +192,7 @@ void ModePlanckTracking::run() {
                       && !high_tension)
               {
                   yaw_cd = copter.flightmode->auto_yaw.yaw();
-                  is_yaw_rate = paylod_yaw_rate;
+                  is_yaw_rate = is_paylod_yaw_rate;
               }
 
               //Convert this to quaternions, yaw rates
@@ -286,7 +301,14 @@ void ModePlanckTracking::run() {
                           pos_cmd.z = new_alt_cm;
                       }
                   }
-                  if(is_yaw_rate)
+
+                  //use payload yaw rate if we have it
+                  if(use_paylod_yaw_rate && is_paylod_yaw_rate)
+                  {
+                    yaw_rate_cmd = payload_yaw_rate_cds;
+                    is_yaw_rate = use_paylod_yaw_rate;
+                  }
+                  else if(is_yaw_rate)
                   {
                     yaw_rate_cmd = yaw_cmd;
                   }

--- a/ArduCopter/mode_plancktracking.cpp
+++ b/ArduCopter/mode_plancktracking.cpp
@@ -52,7 +52,7 @@ void ModePlanckTracking::run() {
       // so we add that offset to the current vehicle heading to obtain the desired absoute heading.
       // Note that the getter method "get_follow_yaw_rate()" is poorly named; it is not a rate,
       // it's the differene between vehicle and gimbal heading.
-      if(mount != nullptr) {
+      if(mount != nullptr && ((mount->get_last_mount_control_time_us() > 0) || (mount->get_last_payload_update_us > 0))) {
         if(mount->mount_yaw_follow_mode == AP_Mount::vehicle_yaw_follows_gimbal) {
 
           //only set new yaw command if payload data is recent (1/2 sec)


### PR DESCRIPTION
[AVEM-1408](https://planckaero.atlassian.net/browse/AVEM-1408)

This PR adds a check to verify a message from either a gimbal or the VSCI tablet has been received before using the payload yaw control logic in mode_plancktracking. Currently, it only checks whether a gimbal mount object has been created, which will be true if configured as such, even even no gimbal is present. This PR aims to verify a gimbal is present in addition to the gimbal mount object existing, before using any payload yaw logic.

Without these changes, the payload yaw logic will execute using incorrect data, resulting in unexpected yaw behavior. It has been observed that this results in yawing close to north.